### PR TITLE
scan-for-updates: install GAP via apt-get

### DIFF
--- a/.github/workflows/scan-for-updates.yml
+++ b/.github/workflows/scan-for-updates.yml
@@ -33,17 +33,10 @@ jobs:
           pip install -r _tools/requirements.txt
 
       - name: "Install GAP"
-        uses: gap-actions/setup-gap@v2
-        with:
-          GAP_BOOTSTRAP: 'minimal'
-          GAP_PKGS_TO_CLONE: 'json'
-          GAP_PKGS_TO_BUILD: 'json'
+        run: sudo apt-get install gap
 
       - name: "Scan for updates"
-        run: |
-          # first put GAP into PATH
-          ln -s /home/runner/gap/bin/gap.sh /usr/local/bin/gap
-          _tools/scan_for_updates.py
+        run: _tools/scan_for_updates.py
 
       - name: "Upload metadata as artifact for pull request jobs"
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
We only need GAP here to parse the PackageInfo.g files