### PR TITLE
Revert "scan-for-updates: install GAP via apt-get"

### DIFF
--- a/.github/workflows/scan-for-updates.yml
+++ b/.github/workflows/scan-for-updates.yml
@@ -33,10 +33,17 @@ jobs:
           pip install -r _tools/requirements.txt
 
       - name: "Install GAP"
-        run: sudo apt-get install --no-install-recommends gap-core
+        uses: gap-actions/setup-gap@v2
+        with:
+          GAP_BOOTSTRAP: 'minimal'
+          GAP_PKGS_TO_CLONE: 'json'
+          GAP_PKGS_TO_BUILD: 'json'
 
       - name: "Scan for updates"
-        run: _tools/scan_for_updates.py
+        run: |
+          # first put GAP into PATH
+          ln -s $HOME/gap/bin/gap.sh /usr/local/bin/gap
+          _tools/scan_for_updates.py
 
       - name: "Upload metadata as artifact for pull request jobs"
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This reverts commit 94156496cd6281055393e084d02b38dea3f9120f.

Unfortunately we also need the JSON package and that is not
installed by the Ubuntu package by default.

All of this would not be necessary if we just had our own
container

Hopefully fixes #153 