### PR TITLE
Fix code for obtaining old metadata

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: "Obtain copy of old metadata, if any"
         run: |
-          git show ${{ github.event.pull_request.base.sha }}:${{ matrix.package }}/meta.json > packages/${{ matrix.package }}/meta.json.old || :
+          git cat-file blob ${{ github.event.pull_request.base.sha }}:packages/${{ matrix.package }}/meta.json > packages/${{ matrix.package }}/meta.json.old || :
 
       - name: "Validate metadata"
         run: |


### PR DESCRIPTION
First, a wrong path was used (lacking the 'packages/' prefix). Second,
the correct git plumbing command is 'cat-files', not 'show', which has
the wrong semantics
