### PR TITLE
Once again only write pkginfo.g files when the hash is new

### DIFF
--- a/tools/scan_for_updates.py
+++ b/tools/scan_for_updates.py
@@ -87,8 +87,8 @@ def scan_for_one_update(pkginfos_dir: str, pkg_name: str) -> None:
     hash_url = hashlib.sha256(pkg_info).hexdigest()
     if hash_url != hash_distro:
         notice(pkg_name + ": detected different sha256 hash of PackageInfo.g")
-    with open(join(pkginfos_dir, pkg_name + ".g"), "wb") as f:
-        f.write(pkg_info)
+        with open(join(pkginfos_dir, pkg_name + ".g"), "wb") as f:
+            f.write(pkg_info)
 
 
 def scan_for_updates(pkginfos_dir = pkginfos_dir, disable_threads = False):


### PR DESCRIPTION
This was modified when we merged the tools repository. But it was only
needed due to a minor mistake in the conversion of 'add_sha256_to_json'.
The latter was fixed in d76a56a867267405e2d4903cc7c1204eba4517c8, so it
should be safe to restore this code, too
