### PR TITLE
Use ccache to speed up compilation; switch gap.tar.gz to gap.tar.zst (smaller, yet created faster)

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -201,13 +201,13 @@ jobs:
           fi
 
       - name: "Run tests"
-        timeout-minutes: 20
+        timeout-minutes: 12
         run: |
           PKG=${{ matrix.package }}
           gap -A --quitonbreak -r -c "SetInfoLevel(InfoPackageLoading, PACKAGE_WARNING);res:=TestPackage(\"$PKG\");FORCE_QUIT_GAP(res);"
 
       - name: "Run tests with OnlyNeeded"
-        timeout-minutes: 20
+        timeout-minutes: 12
         run: |
           PKG=${{ matrix.package }}
           gap -A --quitonbreak -r -c "SetInfoLevel(InfoPackageLoading, PACKAGE_WARNING);res:=TestPackage(\"$PKG\":OnlyNeeded);FORCE_QUIT_GAP(res);"

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -134,13 +134,13 @@ jobs:
       - name: "Create tarball"
         run: |
           cd $HOME
-          tar --exclude-vcs --exclude=build --exclude=.libs --auto-compress -cf gap.tar.gz gap
+          tar --exclude-vcs --exclude=build --exclude=.libs -cf gap.tar.zst gap
 
       - name: "Upload GAP with packages as artifact"
         uses: actions/upload-artifact@v2
         with:
           name: gap
-          path: /home/runner/gap.tar.gz
+          path: /home/runner/gap.tar.zst
 
       - name: "Creates jobs for all packages"
         id: get-names
@@ -186,7 +186,7 @@ jobs:
       - name: "Extract GAP artifact"
         run: |
           cd $HOME
-          tar xvf $GITHUB_WORKSPACE/gap.tar.gz
+          tar xvf $GITHUB_WORKSPACE/gap.tar.zst
           ln -s $HOME/gap/bin/gap.sh /usr/local/bin/gap
           cd $GITHUB_WORKSPACE
 

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -62,6 +62,13 @@ jobs:
       - name: "Cleanup archives"
         run: tools/cleanup_archives.py
 
+      # Setup ccache, to speed up repeated compilation of the same binaries
+      # (i.e., GAP and the packages)
+      - name: Setup ccache
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
+
       # TOOD: gap should come from a container
       - name: "Install GAP"
         run: |


### PR DESCRIPTION
Resolves #162

Still need to test if this helps at all...

UPDATE: It does help! The two changes in this PR made `test-all.yml` go from [~15 minutes](https://github.com/fingolfin/PackageDistro/actions/runs/1990136196) to [~6 minutes](https://github.com/fingolfin/PackageDistro/actions/runs/1990220386) with a "hot cache".