### PR TITLE
Download byte exact copies of PackageInfo.g files

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1,6 +1,13 @@
-name: Run tests
+#
+# This workflow tests the Python scripts in the 'tools' directory
+#
+name: "Test Python tools"
 
-on: workflow_dispatch  # for debugging
+on:
+  workflow_dispatch:  # manual trigger for debugging
+  pull_request:
+    paths:
+      - 'tools/*'
 
 jobs:
   py39: 
@@ -15,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          python -m pip install -r tools/requirements.txt
           python -m pip install pytest mock
           
       - name: Run tests

--- a/packages/fining/meta.json
+++ b/packages/fining/meta.json
@@ -58,7 +58,7 @@
       "SixFile": "doc/manual.six"
     }
   ],
-  "PackageInfoSHA256": "367a69d0bb2160d9c63f2741cba5236374aa614fb7234aeef599c01140767f1c",
+  "PackageInfoSHA256": "415c7716cffcc01efa519497ea572b0d1e5804e86fbe83f67d5fd259f1b4b7c6",
   "PackageInfoURL": "http://cage.ugent.be/fining/PackageInfo.g",
   "PackageName": "FinInG",
   "PackageWWWHome": "http://www.fining.org",
@@ -110,12 +110,12 @@
     {
       "Email": "michel.lavrauw@unipd.it",
       "FirstNames": "Michel",
-      "Institution": "Sabanc� �niversitesi, and Universit� degli Studi di Padova",
+      "Institution": "Sabancõ niversitesi, and Universit degli Studi di Padova",
       "IsAuthor": true,
       "IsMaintainer": true,
       "LastName": "Lavrauw",
       "Place": "Istanbul, and Vicenza",
-      "PostalAddress": "Michel Lavrauw\nFaculty of Engineering and Natural Sciences\nSabanc� �niversitesi\nIstanbul\nTurkey\nUniversit� degli Studi di Padova\nDipartimento di Tecnica e Gestione dei Sistemi Industriali\nStradella S. Nicola, 3\nI-36100\nItaly",
+      "PostalAddress": "Michel Lavrauw\nFaculty of Engineering and Natural Sciences\nSabancõ niversitesi\nIstanbul\nTurkey\nUniversit degli Studi di Padova\nDipartimento di Tecnica e Gestione dei Sistemi Industriali\nStradella S. Nicola, 3\nI-36100\nItaly",
       "WWWHome": "http://people.sabanciuniv.edu/~mlavrauw/"
     },
     {

--- a/tools/scan_for_updates.py
+++ b/tools/scan_for_updates.py
@@ -51,8 +51,7 @@ def download_pkg_info(pkg_name: str) -> str:
             )
         )
         return False
-    response.encoding = "utf-8"
-    return response.text.encode("utf-8")
+    return response.content
 
 
 @accepts(str, str)


### PR DESCRIPTION
... instead of assuming they are UTF-8 encoded and "decoding" them.

While most PackageInfo.g these days are either pure ASCII or use UTF-8
encoding, this is not true for all of them. But by changing the
encoding, we get a false validation error once we compare the file
against its twin in the package archive.
