### PR TITLE
Improve package validation

### DIFF
--- a/tools/scan_for_updates.py
+++ b/tools/scan_for_updates.py
@@ -56,7 +56,7 @@ def download_pkg_info(pkg_name: str) -> str:
 
 
 @accepts(str, str)
-def gap_exec(commands: str, gap="gap") -> int:
+def gap_exec(commands: str, args="") -> int:
 
     with subprocess.Popen(
         r'echo "{}"'.format(commands),
@@ -64,10 +64,9 @@ def gap_exec(commands: str, gap="gap") -> int:
         shell=True,
     ) as cmd:
         with subprocess.Popen(
-            gap,
+            "gap -A -b --quitonbreak -q " + args,
             stdin=cmd.stdout,
             shell=True,
-            stdout=subprocess.DEVNULL,
         ) as GAP:
             GAP.wait()
             return GAP.returncode
@@ -108,7 +107,7 @@ def output_json(updated_pkgs, pkginfos_dir = pkginfos_dir):
     str = '\\", \\"'.join(updated_pkgs)
     result = gap_exec(
             r"OutputJson([\"{}\"], \"{}\");".format(str, pkginfos_dir),
-            gap="gap -A -b {}/scan_for_updates.g".format(dir_of_this_file),
+            gap="{}/scan_for_updates.g".format(dir_of_this_file),
         )
     if result != 0:
         error("Something went wrong")


### PR DESCRIPTION
- fix bug that caused the GAP part of the validation to not be invoked anymore
- changed `gap_exec` helper to not suppress GAP output completely anymore,
  so that we can see the output of GAP's `ValidatePackageInfo` function
- add basic validation for tarballs (resolves #166)
