### PR TITLE
Update linearalgebraforcap to 2022.03-04, cap to 2022.03-06

### DIFF
--- a/packages/cap/meta.json
+++ b/packages/cap/meta.json
@@ -1,10 +1,10 @@
 {
   "AbstractHTML": "<span class=\"pkgname\">CAP</span> (Categories, Algorithms, Programming) is a package for category theory.\nIt facilitates the implementation of specific instances of categories\nand provides a language for writing generic categorical algorithms.",
   "ArchiveFormats": ".tar.gz .zip",
-  "ArchiveSHA256": "3c6250e911700e984942795ebad79f07d72e76ea225503eda01ae13930a05a6a",
-  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/CAP-2022.03-05/CAP-2022.03-05",
+  "ArchiveSHA256": "db65d85dbd5f6394a685f6e725bd171527a700d7a4d458030f7ec083966ff37d",
+  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/CAP-2022.03-06/CAP-2022.03-06",
   "AvailabilityTest": null,
-  "Date": "15/03/2022",
+  "Date": "29/03/2022",
   "Dependencies": {
     "ExternalConditions": [],
     "GAP": ">= 4.11.1",
@@ -47,7 +47,7 @@
       "SixFile": "doc/manual.six"
     }
   ],
-  "PackageInfoSHA256": "f53fdf4ab9675ea259dcec55bf8eff23a56be7ca587d98cc18a1e9b95d6d8fd6",
+  "PackageInfoSHA256": "b51bb8102a687095acbe6eb7e93b02cee8b3c9f331c9403d096f77ab631f319e",
   "PackageInfoURL": "https://homalg-project.github.io/CAP_project/CAP/PackageInfo.g",
   "PackageName": "CAP",
   "PackageWWWHome": "https://homalg-project.github.io/pkg/CAP",
@@ -94,5 +94,5 @@
   "Status": "deposited",
   "Subtitle": "Categories, Algorithms, Programming",
   "TestFile": "tst/testall.g",
-  "Version": "2022.03-05"
+  "Version": "2022.03-06"
 }

--- a/packages/linearalgebraforcap/meta.json
+++ b/packages/linearalgebraforcap/meta.json
@@ -1,10 +1,10 @@
 {
   "AbstractHTML": "<span class=\"pkgname\">LinearAlgebraForCAP</span> provides a skeletal model of the category of finite dimensional vector spaces over a computable field.",
   "ArchiveFormats": ".tar.gz .zip",
-  "ArchiveSHA256": "c32e859cddcdeca9246c616ae5eacc7e87cda4bed35046185aa6449dbea25c29",
-  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/LinearAlgebraForCAP-2022.03-03/LinearAlgebraForCAP-2022.03-03",
+  "ArchiveSHA256": "ad73ab8664515578548a2ebf08b899705f4c11c15a45fe30c0a840cc0345d64d",
+  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/LinearAlgebraForCAP-2022.03-04/LinearAlgebraForCAP-2022.03-04",
   "AvailabilityTest": null,
-  "Date": "16/03/2022",
+  "Date": "29/03/2022",
   "Dependencies": {
     "ExternalConditions": [],
     "GAP": ">= 4.11.1",
@@ -55,7 +55,7 @@
       "SixFile": "doc/manual.six"
     }
   ],
-  "PackageInfoSHA256": "682d960439454b016dc7dc5e080e6765daad45a5c5839de00e3d7e82ddc72687",
+  "PackageInfoSHA256": "77711d9c2b795ff0c5c1d5e9bfdf8e14a5c5c498553bbb25fd67fc4eed4ba920",
   "PackageInfoURL": "https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/PackageInfo.g",
   "PackageName": "LinearAlgebraForCAP",
   "PackageWWWHome": "https://homalg-project.github.io/pkg/LinearAlgebraForCAP",
@@ -91,5 +91,5 @@
   "Status": "deposited",
   "Subtitle": "Category of Matrices over a Field for CAP",
   "TestFile": "tst/testall.g",
-  "Version": "2022.03-03"
+  "Version": "2022.03-04"
 }


### PR DESCRIPTION
This two packages have changes that require the two updates to happen simultaneously.

Closes #229. Closes #230.