### PR TITLE
Workaround atlasrep / ctbllib failures

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -127,6 +127,16 @@ jobs:
           # skip xgap: no X11 headers, and no means to test it
           rm -rf xgap*
 
+          # HACK/WORKAROUND: atlasrep's TestFile sets an exit code but does not
+          # actually exit, thus we can't properly detect whether it passed or
+          # failed (and count that as a failur). So we hack around that...
+          echo "QUIT;" >> atlasrep/tst/testauto.g
+
+          # HACK/WORKAROUND: ctbllib's TestFile sets an exit code but does not
+          # actually exit, thus we can't properly detect whether it passed or
+          # failed (and count that as a failur). So we hack around that...
+          echo "QUIT;" >> ctbllib/tst/testauto.g
+
           MAKEFLAGS=-j3 ../bin/BuildPackages.sh --strict
 
       # TODO: the following is disabled because right now it FAILS due to IsSymmetric


### PR DESCRIPTION
Until @ThomasBreuer finds time to release new versions of `atlasrep` and `ctbllib`, we work around the problem with their `TestFile`, so that we get meaningful test results for them.