### PR TITLE
tools: refactor gap_exec

### DIFF
--- a/tools/tests/test_scan_for_updates.py
+++ b/tools/tests/test_scan_for_updates.py
@@ -71,8 +71,8 @@ def test_download_pkg_info(ensure_in_tests_dir):
 def test_exec_gap(ensure_in_tests_dir):
     if shutil.which("gap") == None:
         return
-    assert gap_exec("FORCE_QUIT_GAP(0);") == 0
-    assert gap_exec("FORCE_QUIT_GAP(1);") == 1
+    assert gap_exec("FORCE_QUIT_GAP(0);") == (0, b'')
+    assert gap_exec("FORCE_QUIT_GAP(1);") == (1, b'')
 
 
 def test_scan_for_one_update(ensure_in_tests_dir, tmpdir):

--- a/tools/validate_package.py
+++ b/tools/validate_package.py
@@ -105,8 +105,8 @@ def main(pkgs):
             pkgdir = join(tempdir, validate_tarball(archive_fname))
             shutil.unpack_archive(archive_fname, tempdir)
             validate_package(archive_fname, pkgdir, pkg_name)
-            result = gap_exec(
-                    r"ValidatePackagesArchive(\"{}\", \"{}\");".format(pkgdir, pkg_name),
+            result, _ = gap_exec(
+                    "ValidatePackagesArchive(\"{}\", \"{}\");".format(pkgdir, pkg_name),
                     args="{}/validate_package.g".format(dir_of_this_file),
                 )
             if result != 0:


### PR DESCRIPTION
Directly pipe input into the GAP process, instead of doing it indirectly
via `echo`. This allows us to completely avoid shell quoting issues.

Moreover, capture the output of the GAP process, so that in the future
we can e.g. let GAP print JSON to stdout and parse that in Python.
