### PR TITLE
Fix crashes in digraphs and semigroups (hopefully)

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -161,6 +161,12 @@ jobs:
           # skip xgap: no X11 headers, and no means to test it
           rm -rf xgap*
 
+          # HACK/WORKAROUND: excise march=native from configure
+          perl -pi -e 's;\bCXXFLAGS=-march=native;;' digraphs/configure
+          perl -pi -e 's;\bCXXFLAGS=-march=native;;' semigroups/configure
+          perl -pi -e 's;as_fn_append CXXFLAGS " -march=native";;' digraphs/configure
+          perl -pi -e 's;as_fn_append CXXFLAGS " -march=native";;' semigroups/configure
+
           # HACK/WORKAROUND: ctbllib's TestFile sets an exit code but does not
           # actually exit, thus we can't properly detect whether it passed or
           # failed (and count that as a failur). So we hack around that...

--- a/packages/linearalgebraforcap/meta.json
+++ b/packages/linearalgebraforcap/meta.json
@@ -1,10 +1,10 @@
 {
   "AbstractHTML": "<span class=\"pkgname\">LinearAlgebraForCAP</span> provides a skeletal model of the category of finite dimensional vector spaces over a computable field.",
   "ArchiveFormats": ".tar.gz .zip",
-  "ArchiveSHA256": "ad73ab8664515578548a2ebf08b899705f4c11c15a45fe30c0a840cc0345d64d",
-  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/LinearAlgebraForCAP-2022.03-04/LinearAlgebraForCAP-2022.03-04",
+  "ArchiveSHA256": "dac7749ad04cae8f1a1cbcada442ae0cc682eac99be50375f418362be602e971",
+  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/LinearAlgebraForCAP-2022.03-05/LinearAlgebraForCAP-2022.03-05",
   "AvailabilityTest": null,
-  "Date": "29/03/2022",
+  "Date": "01/04/2022",
   "Dependencies": {
     "ExternalConditions": [],
     "GAP": ">= 4.11.1",
@@ -55,7 +55,7 @@
       "SixFile": "doc/manual.six"
     }
   ],
-  "PackageInfoSHA256": "77711d9c2b795ff0c5c1d5e9bfdf8e14a5c5c498553bbb25fd67fc4eed4ba920",
+  "PackageInfoSHA256": "596e38a7748d6c0515bf5b13f269ec62361cb8f4e7d7abb7f035a67cf68ac8b0",
   "PackageInfoURL": "https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/PackageInfo.g",
   "PackageName": "LinearAlgebraForCAP",
   "PackageWWWHome": "https://homalg-project.github.io/pkg/LinearAlgebraForCAP",
@@ -91,5 +91,5 @@
   "Status": "deposited",
   "Subtitle": "Category of Matrices over a Field for CAP",
   "TestFile": "tst/testall.g",
-  "Version": "2022.03-04"
+  "Version": "2022.03-05"
 }

--- a/packages/matgrp/meta.json
+++ b/packages/matgrp/meta.json
@@ -1,15 +1,15 @@
 {
   "AbstractHTML": "The <span class=\"pkgname\">matgrp</span> package provides an interface to the solvable radical functionality for matrix groups, building on constructive recognition.",
   "ArchiveFormats": ".tar.gz",
-  "ArchiveSHA256": "f852faae6606d40e004127c50021e0759ff31e770f78d527bb3277e7430bf2b5",
-  "ArchiveURL": "http://www.math.colostate.edu/~hulpke/matgrp/matgrp0.64",
+  "ArchiveSHA256": "4f773cadc9548553fbe3429acbda4a82b9e0eb110e11888663d5ca2079a7862f",
+  "ArchiveURL": "http://www.math.colostate.edu/~hulpke/matgrp/matgrp0.70",
   "Autoload": false,
   "AvailabilityTest": null,
   "BannerString": "Matrix Group Interface routines by A. Hulpke\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n",
-  "Date": "25/08/2020",
+  "Date": "01/03/2022",
   "Dependencies": {
     "ExternalConditions": [],
-    "GAP": ">=4.7",
+    "GAP": ">=4.12",
     "NeededOtherPackages": [
       [
         "recog",
@@ -55,7 +55,7 @@
       "SixFile": "doc/manual.six"
     }
   ],
-  "PackageInfoSHA256": "32daa40880e032ab48776fe3410288a9ace920d4804d4b47bc98324d8f28bfc5",
+  "PackageInfoSHA256": "b6d3cd7842a16d169b582226e04141b395a6ca6e167c9aeef5a6fd7297398d28",
   "PackageInfoURL": "http://www.math.colostate.edu/~hulpke/matgrp/PackageInfo.g",
   "PackageName": "matgrp",
   "PackageWWWHome": "http://www.math.colostate.edu/~hulpke/matgrp",
@@ -79,5 +79,5 @@
   "Status": "deposited",
   "Subtitle": "Matric Group Interface Routines",
   "TestFile": "tst/testall.g",
-  "Version": "0.64"
+  "Version": "0.70"
 }


### PR DESCRIPTION
This patch is an attempt to resolve random crashes we have been seeing in CI
whenever digraphs and/or semigroups are loaded. The theory is that this is
caused by their use of `-march=native`, combined with the fact that we use
`ccache`, yet the results run on different VMs. So perhaps one day a binary is
compiled on one computer, and put into the cache; then another day the same
file is compiled again but on a different computer, and the compilation result
is retrieved from the cache. But since the computer has a different CPU, the
binary does not actually run there due to its use of `-march=native`.

Time will tell if this helps or not...
