### PR TITLE
Add PR comments with status reports (WIP)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -88,3 +88,54 @@ jobs:
     uses: ./.github/workflows/test-all.yml
     with:
       which-gap: '4.11.1'
+
+  status-comment:
+    name: "Create or update PR comment"
+    runs-on: ubuntu-latest
+    needs: test-all-master # TODO: also handle test-all-release
+    if: always()
+    steps:
+      - name: "Download report"
+        uses: actions/download-artifact@v3
+        with:
+          name: report-master
+          path: _report
+
+      - name: "Prepare report.md"
+        id: get-comment-body
+        run: |
+          body="$(cat _report/report.md)"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
+
+      - name: "Find Comment"
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          #comment-author: "gap-package-distribution-bot <100730870+gap-package-distribution-bot[bot]@users.noreply.github.com>"
+          body-includes: "Package Evaluation Report"
+
+      # We set up a GitHub App in order to ensure that workflows are run on the PRs
+      # created by us, following the instructions here:
+      # <https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens>
+      # The bot can also be set up for personal forks of this repository, for testing
+      # and debugging, see <https://github.com/apps/gap-package-distribution-bot>.
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # TODO: extra work is needed to make the following work with pull requests
+      # that come from forks of this repository.
+      - name: "Create or update comment"
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.get-comment-body.outputs.body }}
+          edit-mode: replace

--- a/packages/cap/meta.json
+++ b/packages/cap/meta.json
@@ -1,10 +1,10 @@
 {
   "AbstractHTML": "<span class=\"pkgname\">CAP</span> (Categories, Algorithms, Programming) is a package for category theory.\nIt facilitates the implementation of specific instances of categories\nand provides a language for writing generic categorical algorithms.",
   "ArchiveFormats": ".tar.gz .zip",
-  "ArchiveSHA256": "eef27a16377712627483c44342a5703613397120ec5b81702ab36aaf43805f72",
-  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/CAP-2022.03-07/CAP-2022.03-07",
+  "ArchiveSHA256": "cd99e75b1119a7623addea8877bb2c721d843c756c3d014a2131e0917d5864f9",
+  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/CAP-2022.03-08/CAP-2022.03-08",
   "AvailabilityTest": null,
-  "Date": "31/03/2022",
+  "Date": "01/04/2022",
   "Dependencies": {
     "ExternalConditions": [],
     "GAP": ">= 4.11.1",
@@ -47,7 +47,7 @@
       "SixFile": "doc/manual.six"
     }
   ],
-  "PackageInfoSHA256": "b6e6161c7b7e0b513c208efe177c4eed113134b6adb6f73a0596c157c38e97f2",
+  "PackageInfoSHA256": "6aeb0aed335152a6131fc01fbc9c7125dc23a58acccbd080b36addf549c9cf1d",
   "PackageInfoURL": "https://homalg-project.github.io/CAP_project/CAP/PackageInfo.g",
   "PackageName": "CAP",
   "PackageWWWHome": "https://homalg-project.github.io/pkg/CAP",
@@ -94,5 +94,5 @@
   "Status": "deposited",
   "Subtitle": "Categories, Algorithms, Programming",
   "TestFile": "tst/testall.g",
-  "Version": "2022.03-07"
+  "Version": "2022.03-08"
 }


### PR DESCRIPTION
... unfortunately this won't work for PRs that come from forks... but for now let's try to at least make it work for "internal" PRs...

Note that https://github.com/marketplace/actions/create-or-update-comment suggests it might be possible to use a `pull_request_target` trigger, but I am not yet sure how we'd possibly do that