### PR TITLE
Better workaround for ccache -march=native trouble

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,6 +45,7 @@ jobs:
           cc -v
           echo "c++ -march=native: $(tools/compiler_arch.sh c++)"
           c++ -v
+          echo "$PWD/tools" >> $GITHUB_PATH
 
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
@@ -53,7 +54,7 @@ jobs:
         with:
           update_packager_index: false
           ccache_options: |
-              compiler_check = %compiler% -v ; ${{ env.PWD }}/tools/compiler_arch.sh %compiler%
+              compiler_check = %compiler% -v ; compiler_arch.sh %compiler%
 
       - name: "Install GAP"
         uses: gap-actions/setup-gap@4e865453a9185dfd6d47cdd97e5ce011bee37e9a

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,12 +39,21 @@ jobs:
       - name: "Install package distribution tools"
         run: python -m pip install -r tools/requirements.txt
 
+      - name: "Determine system architecture for ccache"
+        run: |
+          echo "cc -march=native: $(tools/compiler_arch.sh cc)"
+          cc -v
+          echo "c++ -march=native: $(tools/compiler_arch.sh c++)"
+          c++ -v
+
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
       - name: "Setup ccache"
         uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          ccache_options: |
+              compiler_check = %compiler% -v ; tools/compiler_arch.sh %compiler%
 
       - name: "Install GAP"
         uses: gap-actions/setup-gap@4e865453a9185dfd6d47cdd97e5ce011bee37e9a

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           update_packager_index: false
           ccache_options: |
-              compiler_check = %compiler% -v ; tools/compiler_arch.sh %compiler%
+              compiler_check = %compiler% -v ; ${{ env.PWD }}/tools/compiler_arch.sh %compiler%
 
       - name: "Install GAP"
         uses: gap-actions/setup-gap@4e865453a9185dfd6d47cdd97e5ce011bee37e9a

--- a/.github/workflows/scan-for-updates.yml
+++ b/.github/workflows/scan-for-updates.yml
@@ -34,12 +34,21 @@ jobs:
           restore-keys: |
             archives-
 
+      - name: "Determine system architecture for ccache"
+        run: |
+          echo "cc -march=native: $(tools/compiler_arch.sh cc)"
+          cc -v
+          echo "c++ -march=native: $(tools/compiler_arch.sh c++)"
+          c++ -v
+
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
       - name: "Setup ccache"
         uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          ccache_options: |
+              compiler_check = %compiler% -v ; tools/compiler_arch.sh %compiler%
 
       - name: "Install GAP"
         uses: gap-actions/setup-gap@v2

--- a/.github/workflows/scan-for-updates.yml
+++ b/.github/workflows/scan-for-updates.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           update_packager_index: false
           ccache_options: |
-              compiler_check = %compiler% -v ; tools/compiler_arch.sh %compiler%
+              compiler_check = %compiler% -v ; ${{ env.PWD }}/tools/compiler_arch.sh %compiler%
 
       - name: "Install GAP"
         uses: gap-actions/setup-gap@v2

--- a/.github/workflows/scan-for-updates.yml
+++ b/.github/workflows/scan-for-updates.yml
@@ -40,6 +40,7 @@ jobs:
           cc -v
           echo "c++ -march=native: $(tools/compiler_arch.sh c++)"
           c++ -v
+          echo "$PWD/tools" >> $GITHUB_PATH
 
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
@@ -48,7 +49,7 @@ jobs:
         with:
           update_packager_index: false
           ccache_options: |
-              compiler_check = %compiler% -v ; ${{ env.PWD }}/tools/compiler_arch.sh %compiler%
+              compiler_check = %compiler% -v ; compiler_arch.sh %compiler%
 
       - name: "Install GAP"
         uses: gap-actions/setup-gap@v2

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           update_packager_index: false
           ccache_options: |
-              compiler_check = %compiler% -v ; tools/compiler_arch.sh %compiler%
+              compiler_check = %compiler% -v ; ${{ env.PWD }}/tools/compiler_arch.sh %compiler%
 
       # TOOD: gap should come from a container
       - name: "Install GAP"

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -94,6 +94,7 @@ jobs:
           cc -v
           echo "c++ -march=native: $(tools/compiler_arch.sh c++)"
           c++ -v
+          echo "$PWD/tools" >> $GITHUB_PATH
 
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
@@ -102,7 +103,7 @@ jobs:
         with:
           update_packager_index: false
           ccache_options: |
-              compiler_check = %compiler% -v ; ${{ env.PWD }}/tools/compiler_arch.sh %compiler%
+              compiler_check = %compiler% -v ; compiler_arch.sh %compiler%
 
       # TOOD: gap should come from a container
       - name: "Install GAP"

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -88,12 +88,21 @@ jobs:
       - name: "Cleanup archives"
         run: tools/cleanup_archives.py
 
+      - name: "Determine system architecture for ccache"
+        run: |
+          echo "cc -march=native: $(tools/compiler_arch.sh cc)"
+          cc -v
+          echo "c++ -march=native: $(tools/compiler_arch.sh c++)"
+          c++ -v
+
       # Setup ccache, to speed up repeated compilation of the same binaries
       # (i.e., GAP and the packages)
       - name: "Setup ccache"
         uses: Chocobo1/setup-ccache-action@v1
         with:
           update_packager_index: false
+          ccache_options: |
+              compiler_check = %compiler% -v ; tools/compiler_arch.sh %compiler%
 
       # TOOD: gap should come from a container
       - name: "Install GAP"
@@ -160,12 +169,6 @@ jobs:
 
           # skip xgap: no X11 headers, and no means to test it
           rm -rf xgap*
-
-          # HACK/WORKAROUND: excise march=native from configure
-          perl -pi -e 's;\bCXXFLAGS=-march=native;;' digraphs/configure
-          perl -pi -e 's;\bCXXFLAGS=-march=native;;' semigroups/configure
-          perl -pi -e 's;as_fn_append CXXFLAGS " -march=native";;' digraphs/configure
-          perl -pi -e 's;as_fn_append CXXFLAGS " -march=native";;' semigroups/configure
 
           # HACK/WORKAROUND: ctbllib's TestFile sets an exit code but does not
           # actually exit, thus we can't properly detect whether it passed or

--- a/packages/classicpres/meta.json
+++ b/packages/classicpres/meta.json
@@ -1,0 +1,95 @@
+{
+  "AbstractHTML": "The <span class=\"pkgname\">classicpres</span> package provides presentations for classical groups, translated from the corresponding Magma code.",
+  "ArchiveFormats": ".tar.gz",
+  "ArchiveSHA256": "aeb6bbd1d4534b80ed0770f419db1980518dd946fea1a768c5a026138cddb6b7",
+  "ArchiveURL": "http://www.math.colostate.edu/~hulpke/classicpres/classicpres1.21",
+  "Autoload": true,
+  "AvailabilityTest": null,
+  "BannerString": "Classical Group Presentations\n",
+  "Date": "21/03/2022",
+  "Dependencies": {
+    "ExternalConditions": [],
+    "GAP": ">=4.11",
+    "NeededOtherPackages": [
+      [
+        "AtlasRep",
+        ">= 1.4.0"
+      ]
+    ],
+    "SuggestedOtherPackages": []
+  },
+  "IssueTrackerURL": "https://github.com/hulpke/magmapresentations//issues",
+  "Keywords": [
+    "classical group",
+    "presentation"
+  ],
+  "License": "GPL-2.0 OR GPL-3.0",
+  "PackageDoc": [
+    {
+      "ArchiveURLSubset": [
+        "doc",
+        "htm"
+      ],
+      "Autoload": true,
+      "BookName": "classicpres",
+      "HTMLStart": "htm/chapters.htm",
+      "LongTitle": "Classical Group Presentations",
+      "PDFFile": "doc/manual.pdf",
+      "SixFile": "doc/manual.six"
+    }
+  ],
+  "PackageInfoSHA256": "39c55ec8c1cc1b9b22768b975f9a180458c1014cb3e5e304131b48b405fe478c",
+  "PackageInfoURL": "http://www.math.colostate.edu/~hulpke/classicpres/PackageInfo.g",
+  "PackageName": "classicpres",
+  "PackageWWWHome": "http://www.math.colostate.edu/~hulpke/classicpres",
+  "Persons": [
+    {
+      "Email": "hulpke@math.colostate.edu",
+      "FirstNames": "Alexander",
+      "Institution": "Department of Mathematics, Colorado State University",
+      "IsAuthor": true,
+      "IsMaintainer": true,
+      "LastName": "Hulpke",
+      "Place": "Fort Collins, CO",
+      "WWWHome": "http://www.math.colostate.edu/~hulpke"
+    },
+    {
+      "Email": "obrien@math.auckland.ac.nz",
+      "FirstNames": "Eamonn",
+      "Institution": "University of Auckland",
+      "IsAuthor": true,
+      "IsMaintainer": false,
+      "LastName": "O'Brien",
+      "Place": "Auckland",
+      "PostalAddress": "Department of Mathematics\nUniversity of Auckland\nPrivate Bag 92019\nAuckland\nNew Zealand\n",
+      "WWWHome": "http://www.math.auckland.ac.nz/~obrien"
+    },
+    {
+      "FirstNames": "Charles",
+      "IsAuthor": true,
+      "IsMaintainer": false,
+      "LastName": "Leedham-Green"
+    },
+    {
+      "FirstNames": "Madeleine",
+      "IsAuthor": true,
+      "IsMaintainer": false,
+      "LastName": "Whybrow"
+    },
+    {
+      "FirstNames": "Giovanni",
+      "IsAuthor": true,
+      "IsMaintainer": false,
+      "LastName": "de Franceschi"
+    }
+  ],
+  "README_URL": "http://www.math.colostate.edu/~hulpke/classicpres/README.md",
+  "SourceRepository": {
+    "Type": "git",
+    "URL": "https://github.com/hulpke/magmapresentations/"
+  },
+  "Status": "deposited",
+  "Subtitle": "Classical Group Presentations",
+  "TestFile": "tst/testall.g",
+  "Version": "1.21"
+}

--- a/tools/compiler_arch.sh
+++ b/tools/compiler_arch.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+compiler=$1
+${compiler} -march=native "-###" -E - < /dev/null 2>&1 | sed -ne 's/.*cc1 .*-march=\([^ "]*\)[ "].*/\1/p'


### PR DESCRIPTION
To distinguish the compiler, don't rely on just the compiler's mtime,
but also take into account the architecture selected by `-march=native`
as well as the exact compiler version.
