### PR TITLE
Refactor download related code

### DIFF
--- a/tools/download_packages.py
+++ b/tools/download_packages.py
@@ -42,9 +42,8 @@ from os.path import join
 
 from typing import List
 
-import requests
-
 from utils import (
+    download,
     error,
     notice,
     normalize_pkg_name,
@@ -55,9 +54,7 @@ from utils import (
 )
 
 
-def download_archive(  # pylint: disable=inconsistent-return-statements
-    archive_dir: str, pkg_name: str, tries: int = 5
-) -> str:
+def download_archive(archive_dir: str, pkg_name: str) -> str:
     """Returns the full archive name (including archive_dir) for the downloaded
     archive of the package `pkg_name`"""
     if not os.path.exists(archive_dir):
@@ -78,22 +75,8 @@ def download_archive(  # pylint: disable=inconsistent-return-statements
             return archive_fname
     url = archive_url(pkg_json)
     notice(f"downloading {url} to {archive_fname}")
-
-    for i in range(tries):
-        try:
-            response = requests.get(url, stream=True)
-            if response.status_code != 200:
-                notice(f"exited with HTTP status {response.status_code}")
-                break
-            with open(archive_fname, "wb") as f:
-                for chunk in response.raw.stream(1024, decode_content=False):
-                    if chunk:
-                        f.write(chunk)
-            return archive_fname
-        except requests.RequestException:
-            notice(f"  attempt {i+1}/{tries} failed")
-
-    error(f"  failed to download archive {archive_fname}")
+    download(url, archive_fname)
+    return archive_fname
 
 
 def main(pkg_names: List[str]) -> None:

--- a/tools/tests/test_download_packages.py
+++ b/tools/tests/test_download_packages.py
@@ -109,10 +109,9 @@ def test_download_archive(ensure_in_tests_dir, tmpdir):
     with mock.patch(
         "requests.get", side_effect=RequestException("Failed Request")
     ) as mock_request_post:
-        with pytest.raises(SystemExit) as e:
+        with pytest.raises(RequestException) as e:
             download_archive(str(tmpdir), "toricvarieties")
-        assert e.type == SystemExit
-        assert e.value.code == 1
+        assert e.type == RequestException
 
     download_archive(str(tmpdir), "aclib")
     assert exists(join(str(tmpdir), archive_name("aclib")))

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -51,10 +51,17 @@ def sha256(fname: str) -> str:
 def download(url: str, dst: str) -> None:
     """Download the file at the given URL `url` to the file with path `dst`."""
     response = requests.get(url, stream=True)
+    response.raise_for_status()  # raise a meaningful (?) exception if there was e.g. a 404 error
     with open(dst, "wb") as f:
         for chunk in response.raw.stream(16384, decode_content=False):
             if chunk:
                 f.write(chunk)
+
+
+def download_to_memory(url: str) -> bytes:
+    response = requests.get(url)
+    response.raise_for_status()
+    return response.content
 
 
 def normalize_pkg_name(pkg_name: str) -> str:


### PR DESCRIPTION
- `download_archive` now calls `utils.download` and does not attempt to retry; this simplifies the logic, and I think just rerunning whatever command lead to the error may be the better strategy. Alas, time will tell, we can re-evaluate this should we encounter problems due to temporary download failures too frequently
- moved `download_to_memory` to `utils`
- `download` and `download_to_memory` now raise an exception if the download failed, e.g. with a 404 "file not found" HTTP error
- ...
