### PR TITLE
Run test suite as part of PR CI

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -187,11 +187,13 @@ jobs:
 
           MAKEFLAGS=-j3 ../bin/BuildPackages.sh --strict ${{ github.event.inputs.pkg-build-glob || inputs.pkg-build-glob }}
 
-      - name: "Test LoadAllPackages"
+      - name: "Test LoadAllPackages + GAP test suite"
         run: |
           gap -A --quitonbreak -r -c "
                 SetInfoLevel(InfoPackageLoading, PACKAGE_DEBUG);
                 LoadAllPackages();
+                SetInfoLevel(InfoPackageLoading, PACKAGE_ERROR);
+                ReadGapRoot(\"tst/testinstall.g\");
                 QUIT;
                 "
 


### PR DESCRIPTION
So far we tested that package updates don't break other packages -- but we
did not actually test if they broke GAP's own test suite. So let's change that...

Unfortunately the test suite *is* broken right now, so that has to be fixed first...