### PR TITLE
CAP related package updates

### DIFF
--- a/packages/cap/meta.json
+++ b/packages/cap/meta.json
@@ -1,10 +1,10 @@
 {
   "AbstractHTML": "<span class=\"pkgname\">CAP</span> (Categories, Algorithms, Programming) is a package for category theory.\nIt facilitates the implementation of specific instances of categories\nand provides a language for writing generic categorical algorithms.",
   "ArchiveFormats": ".tar.gz .zip",
-  "ArchiveSHA256": "0f067d9c1878ed547c435366da75f7b138b89732d59af794824b0d42a4a43749",
-  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/CAP-2022.05-02/CAP-2022.05-02",
+  "ArchiveSHA256": "0e7d6c83c6d1cdaf8e97003b04df4692f8eb6d1b0f8dee0e65d1a2505507ab15",
+  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/CAP-2022.05-05/CAP-2022.05-05",
   "AvailabilityTest": null,
-  "Date": "03/05/2022",
+  "Date": "17/05/2022",
   "Dependencies": {
     "ExternalConditions": [],
     "GAP": ">= 4.11.1",
@@ -47,7 +47,7 @@
       "SixFile": "doc/manual.six"
     }
   ],
-  "PackageInfoSHA256": "d1f798c2cc5a2899a129eb9e6a4b4672cba4c43f8b4b2c44c4bbecc839bc9d0e",
+  "PackageInfoSHA256": "0b30fbb3d3c42b9578163cf8c605ad9eb8f680784d7711807cd9cb1db4da60d1",
   "PackageInfoURL": "https://homalg-project.github.io/CAP_project/CAP/PackageInfo.g",
   "PackageName": "CAP",
   "PackageWWWHome": "https://homalg-project.github.io/pkg/CAP",
@@ -94,5 +94,5 @@
   "Status": "deposited",
   "Subtitle": "Categories, Algorithms, Programming",
   "TestFile": "tst/testall.g",
-  "Version": "2022.05-02"
+  "Version": "2022.05-05"
 }

--- a/packages/linearalgebraforcap/meta.json
+++ b/packages/linearalgebraforcap/meta.json
@@ -1,10 +1,10 @@
 {
   "AbstractHTML": "<span class=\"pkgname\">LinearAlgebraForCAP</span> provides a skeletal model of the category of finite dimensional vector spaces over a computable field.",
   "ArchiveFormats": ".tar.gz .zip",
-  "ArchiveSHA256": "45f36e4be1bde31460948ed035cab4226b89d81fb01d358a93857428634b67fb",
-  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/LinearAlgebraForCAP-2022.05-02/LinearAlgebraForCAP-2022.05-02",
+  "ArchiveSHA256": "e096e22de30614b5ce1674ba591d46fb8cd6e5e1ce5ffbd5bb9c8757dff03d7b",
+  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/LinearAlgebraForCAP-2022.05-03/LinearAlgebraForCAP-2022.05-03",
   "AvailabilityTest": null,
-  "Date": "03/05/2022",
+  "Date": "17/05/2022",
   "Dependencies": {
     "ExternalConditions": [],
     "GAP": ">= 4.11.1",
@@ -55,7 +55,7 @@
       "SixFile": "doc/manual.six"
     }
   ],
-  "PackageInfoSHA256": "fc7121bf94d4ab0ba53c2b6fd8db21ea2cff3e973739a57a96aacddac0d98578",
+  "PackageInfoSHA256": "2982560fc79590dd19770dfb6a8f5f8675933a4a463a61ff46a3755e078b469b",
   "PackageInfoURL": "https://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/PackageInfo.g",
   "PackageName": "LinearAlgebraForCAP",
   "PackageWWWHome": "https://homalg-project.github.io/pkg/LinearAlgebraForCAP",
@@ -91,5 +91,5 @@
   "Status": "deposited",
   "Subtitle": "Category of Matrices over a Field for CAP",
   "TestFile": "tst/testall.g",
-  "Version": "2022.05-02"
+  "Version": "2022.05-03"
 }

--- a/packages/modulepresentationsforcap/meta.json
+++ b/packages/modulepresentationsforcap/meta.json
@@ -1,10 +1,10 @@
 {
   "AbstractHTML": "<span class=\"pkgname\">ModulePresentationsForCAP</span> provides the category of finitely presented modules over a computable ring.",
   "ArchiveFormats": ".tar.gz .zip",
-  "ArchiveSHA256": "fde9082717f279c32239fc7aaecba7f56c549c44932d3c384843739e08151566",
-  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/ModulePresentationsForCAP-2022.05-01/ModulePresentationsForCAP-2022.05-01",
+  "ArchiveSHA256": "a302b63f3530b82d7a93d451583b996fcca8c075e0362f08f21eea50828ab9f0",
+  "ArchiveURL": "https://github.com/homalg-project/CAP_project/releases/download/ModulePresentationsForCAP-2022.05-02/ModulePresentationsForCAP-2022.05-02",
   "AvailabilityTest": null,
-  "Date": "03/05/2022",
+  "Date": "17/05/2022",
   "Dependencies": {
     "ExternalConditions": [],
     "GAP": ">= 4.11.1",
@@ -51,7 +51,7 @@
       "SixFile": "doc/manual.six"
     }
   ],
-  "PackageInfoSHA256": "a7848f48fd58a8b51b880df492074de4a183853b2393a991bdda6f1520edbd19",
+  "PackageInfoSHA256": "fd9182719dd6a5d9ca3153da08b091a861318d7d66102a75394fc5fa4a6d74c1",
   "PackageInfoURL": "https://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/PackageInfo.g",
   "PackageName": "ModulePresentationsForCAP",
   "PackageWWWHome": "https://homalg-project.github.io/pkg/ModulePresentationsForCAP",
@@ -87,5 +87,5 @@
   "Status": "deposited",
   "Subtitle": "Category R-pres for CAP",
   "TestFile": "tst/testall.g",
-  "Version": "2022.05-01"
+  "Version": "2022.05-02"
 }


### PR DESCRIPTION
- [modulepresentationsforcap] Update to 2022.05-02 closes #366
- [linearalgebraforcap] Update to 2022.05-03 closes #367
- [cap] Update to 2022.05-05 closes #365
