### PR TITLE
Let NormalizInterface build Normaliz

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -163,12 +163,6 @@ jobs:
         run: |
           cd $HOME/gap/pkg
 
-          # HACK: prevent BuildPackages.sh from building the Normaliz verison
-          # "bundled" with NormalizInterface, as this is very slow (takes 5-10
-          # minutes). Instead we want it to use libnormaliz-dev installed by
-          # us
-          rm -f */build-normaliz.sh
-
           # skip xgap: no X11 headers, and no means to test it
           rm -rf xgap*
 

--- a/tools/gather_dependencies.py
+++ b/tools/gather_dependencies.py
@@ -31,7 +31,7 @@ ubtunu_deps = {
     "cddinterface": ["libcdd-dev"],
     "curlinterface": ["libcurl4-openssl-dev"],
     "float": ["libmpc-dev", "libmpfi-dev", "libmpfr-dev"],
-    "normalizinterface": ["libnormaliz-dev"],
+    "normalizinterface": ["libeantic-dev", "libflint-arb-dev", "libflint-dev"],
     "polymaking": ["polymake"],
     "ringsforhomalg": ["singular"],
     "singular": ["singular"],


### PR DESCRIPTION
Thanks to ccache it shouldn't be too bad...

This patch was in there before and reverted because it lead to nconvex crashing. Hopefully not so anymore...

Resolves #285 