### PR TITLE
fix: Fix _archives creation

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -52,6 +52,7 @@ def download(url: str, dst: str) -> None:
     """Download the file at the given URL `url` to the file with path `dst`."""
     response = requests.get(url, stream=True)
     response.raise_for_status()  # raise a meaningful (?) exception if there was e.g. a 404 error
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
     with open(dst, "wb") as f:
         for chunk in response.raw.stream(16384, decode_content=False):
             if chunk:


### PR DESCRIPTION
While importing new package, if only `_archives` directory does not exists, the import wrongly fails.


```
gap-packagedistro on  main λ ./tools/import_packages.py https://limakzi.github.io/smallantimagmas/PackageInfo.g
downloading https://limakzi.github.io/smallantimagmas/PackageInfo.g to tempfile /tmp/pkginfouja6h7cs.g
update packages/smallantimagmas/meta.json
gap-packagedistro on  main λ rm -rvf _archives/
removed '_archives/smallantimagmas-0.2.3.tar.gz'
removed directory '_archives/'
gap-packagedistro on  main λ ./tools/import_packages.py https://limakzi.github.io/smallantimagmas/PackageInfo.g
downloading https://limakzi.github.io/smallantimagmas/PackageInfo.g to tempfile /tmp/pkginfoh_kpnblo.g
Traceback (most recent call last):
  File "/home/limakzi/documents/gap-packagedistro/./tools/import_packages.py", line 38, in <module>
    main(sys.argv[1:])
  File "/home/limakzi/documents/gap-packagedistro/./tools/import_packages.py", line 34, in main
    import_packages(pkginfo_paths)
  File "/home/limakzi/documents/gap-packagedistro/tools/scan_for_updates.py", line 115, in import_packages
    utils.download(url, archive_fname)
  File "/home/limakzi/documents/gap-packagedistro/tools/utils.py", line 55, in download
    with open(dst, "wb") as f:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '_archives/smallantimagmas-0.2.3.tar.gz'
gap-packagedistro on  main λ 
```