### PR TITLE
Fix bug that caused failures in `PackageManager` tests

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -202,7 +202,7 @@ jobs:
       - name: "Create tarball"
         run: |
           cd $HOME
-          tar --exclude-vcs --exclude=build --exclude=.libs -cf gap.tar.zst gap
+          tar --exclude-vcs --exclude=build/obj --exclude=.libs -cf gap.tar.zst gap
 
       - name: "Compute suitable artifact basename"
         id: get-artifact-name


### PR DESCRIPTION
Don't delete `build/ffdata.h` and `build/version.h` as PackageManager needs them to build GAP packages with kernel extensions.

This was a latent bug since 2022, but it was obscured by PackageManager and GAP library behaviour (e.g. installing  e.g. `io` was skipped because it was already installed and workable anyway). Both are stricter now (which is good), and so this bug in the PackageDistro setup was revealed.

Fixes https://github.com/gap-system/gap/issues/5916

CC @mtorpey @lgoettgens @ThomasBreuer 