### PR TITLE
Update ubuntu-20.04 to ubuntu-latest in workflows

### DIFF
--- a/.github/workflows/assemble-distro.yml
+++ b/.github/workflows/assemble-distro.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   assemble:
     name: "Assemble the package distribution"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   detect-changes:
     name: "Detect affected packages"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ !contains( github.event.pull_request.labels.*.name, 'skip tests') }}
     outputs:
       modified: ${{ steps.modified.outputs.modified }}
@@ -102,7 +102,7 @@ jobs:
 
   status-comment:
     name: "Create or update PR comment"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: test-all-master  # TODO: also handle test-all-release
     if: always()
     steps:

--- a/.github/workflows/scan-for-updates.yml
+++ b/.github/workflows/scan-for-updates.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   scan-for-updates:
     name: "Scan for package updates"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-names.outputs.matrix }}
     steps:
@@ -113,7 +113,7 @@ jobs:
     name: "Create pull request for ${{ matrix.package_or_group }}"
     if: ${{ needs.scan-for-updates.outputs.matrix != '{"package_or_group":[]}' }}
     needs: scan-for-updates
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.scan-for-updates.outputs.matrix) }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -69,7 +69,7 @@ jobs:
     # If you change this name, you must adjust the corresponding name
     # in tools/generate_test_status.py
     name: "Build GAP and packages"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-names.outputs.matrix }}
       artifact: ${{ steps.get-artifact-name.outputs.artifact }}
@@ -247,7 +247,7 @@ jobs:
     name: "${{ matrix.package }}"
     if: ${{ needs.build.outputs.matrix != '{"package":[]}' }}
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
@@ -355,7 +355,7 @@ jobs:
     name: "Generate report"
     needs: [build, test-package]
     if: always()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       test-status: ${{ steps.test-status.outputs.test-status }}
     steps:

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   py311:
     name: "Run tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/update-latest-report.yml
+++ b/.github/workflows/update-latest-report.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   update-latest:
     name: "Upload report"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Set up Python"
         uses: actions/setup-python@v5


### PR DESCRIPTION
The github-runner for `ubuntu-20.04` [will completely stop working on April 15](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes), and the workflows of this repo [have previously been impacted by scheduled brownouts](https://github.com/gap-system/PackageDistro/actions/runs/14342630620).

This PR updates the workflows to use `ubuntu-latest`, though `ubuntu-22.04` or `ubuntu-24.04` could also be used of course.