### PR TITLE
Skip empty update PRs

### DIFF
--- a/.github/workflows/scan-for-updates.yml
+++ b/.github/workflows/scan-for-updates.yml
@@ -145,6 +145,19 @@ jobs:
 
           cat $GITHUB_ENV
 
+      - name: "Check whether pull request is still needed"
+        id: check-diff
+        run: |
+          git fetch --no-tags --depth=1 origin \
+            ${{ github.event.repository.default_branch }}
+          paths=${PR_FILES//,/ }
+          if git diff --quiet FETCH_HEAD -- $paths; then
+            echo "skip_pr=true" >> $GITHUB_OUTPUT
+            echo "No changes remain against the latest default branch."
+          else
+            echo "skip_pr=false" >> $GITHUB_OUTPUT
+          fi
+
       # We set up a GitHub App in order to ensure that workflows are run on the PRs
       # created by us, following the instructions here:
       # <https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens>
@@ -152,11 +165,13 @@ jobs:
       # and debugging, see <https://github.com/apps/gap-package-distribution-bot>.
       - uses: actions/create-github-app-token@v3
         id: generate-token
+        if: steps.check-diff.outputs.skip_pr != 'true'
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: peter-evans/create-pull-request@v8
+        if: steps.check-diff.outputs.skip_pr != 'true'
         with:
           token: ${{ steps.generate-token.outputs.token }}
           # https://api.github.com/users/gap-package-distribution-bot%5Bbot%5D


### PR DESCRIPTION
Fetch the latest default branch before creating an update PR. Skip PR creation when the prepared package metadata no longer differs.

Co-authored-by: Codex <codex@openai.com>

Resolves #677
Resolves #239