### PR TITLE
Record and report archive size in PR metadata

### DIFF
--- a/tools/prepare_pr.py
+++ b/tools/prepare_pr.py
@@ -37,12 +37,19 @@ def randomword(length: int) -> str:
     return "".join(random.choice(letters) for i in range(length))
 
 
+def archive_size_mb(pkg_json: Dict[str, Any]) -> str:
+    return f"{pkg_json['ArchiveSize'] / 1_000_000:.1f} MB"
+
+
 def infostr_for_package(pkg_json: Dict[str, Any]) -> str:
     s = f"- {pkg_json['PackageName']} {pkg_json['Version']}: "
     s += f"[[`PackageInfo.g`]({pkg_json['PackageInfoURL']})] "
     s += f"[[`README`]({pkg_json['README_URL']})] "
     s += f"[[website]({pkg_json['PackageWWWHome']})] "
-    s += f"[[source archive]({utils.archive_url(pkg_json)})] "
+    s += (
+        f"[[source archive]({utils.archive_url(pkg_json)}) "
+        f"({archive_size_mb(pkg_json)})] "
+    )
     s += "\n"
     return s
 

--- a/tools/scan_for_updates.py
+++ b/tools/scan_for_updates.py
@@ -114,9 +114,11 @@ def import_packages(pkginfo_paths: List[str]) -> None:
         try:
             utils.download(url, archive_fname)
             pkg_json["ArchiveSHA256"] = sha256(archive_fname)
+            pkg_json["ArchiveSize"] = os.path.getsize(archive_fname)
         except requests.RequestException as e:
             warning(f"{pkgname}: {e}")
             pkg_json["ArchiveSHA256"] = "FAIL"
+            pkg_json["ArchiveSize"] = 0
 
         pkg_json_file = metadata_fname(pkgname)
         notice(f"update {pkg_json_file}")

--- a/tools/tests/test_prepare_pr.py
+++ b/tools/tests/test_prepare_pr.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+sys.path.insert(
+    0, "/".join(os.path.dirname(os.path.realpath(__file__)).split("/")[:-1])
+)
+
+from prepare_pr import infostr_for_package
+
+
+def test_infostr_for_package_includes_archive_size():
+    pkg_json = {
+        "ArchiveFormats": ".tar.gz",
+        "ArchiveSize": 12939427,
+        "ArchiveURL": "https://example.com/testpkg-1.0",
+        "PackageInfoURL": "https://example.com/PackageInfo.g",
+        "PackageName": "TestPkg",
+        "PackageWWWHome": "https://example.com",
+        "README_URL": "https://example.com/README",
+        "Version": "1.0",
+    }
+
+    info = infostr_for_package(pkg_json)
+
+    assert (
+        "[[source archive](https://example.com/testpkg-1.0.tar.gz) (12.9 MB)]" in info
+    )

--- a/tools/tests/test_scan_for_updates.py
+++ b/tools/tests/test_scan_for_updates.py
@@ -12,6 +12,7 @@ import shutil
 import sys
 from os.path import exists, join
 
+import mock
 import pytest
 import requests
 
@@ -19,7 +20,12 @@ sys.path.insert(
     0, "/".join(os.path.dirname(os.path.realpath(__file__)).split("/")[:-1])
 )
 
-from scan_for_updates import main, scan_for_one_update, scan_for_updates
+from scan_for_updates import (
+    import_packages,
+    main,
+    scan_for_one_update,
+    scan_for_updates,
+)
 from utils import download_to_memory, gap_exec, metadata, sha256
 
 
@@ -104,3 +110,31 @@ def test_main_again(ensure_in_tests_dir):
     shutil.rmtree("packages/badjson")
     main()
     reset()
+
+
+def test_import_packages_records_archive_size(ensure_in_tests_dir, tmpdir):
+    pkg_json = {
+        "ArchiveFormats": ".tar.gz",
+        "ArchiveURL": "https://example.com/testpkg-1.0",
+        "PackageName": "TestPkg",
+        "Version": "1.0",
+    }
+    archive_bytes = b"archive-bytes-go-here"
+
+    def fake_download(_url, dst):
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        with open(dst, "wb") as f:
+            f.write(archive_bytes)
+
+    with mock.patch(
+        "scan_for_updates.parse_pkginfo_files", return_value=[pkg_json]
+    ), mock.patch("scan_for_updates.utils.download", side_effect=fake_download):
+        import_packages(["dummy.g"])
+
+    meta = metadata("testpkg")
+    archive_path = "_archives/testpkg-1.0.tar.gz"
+    assert meta["ArchiveSHA256"] == sha256(archive_path)
+    assert meta["ArchiveSize"] == len(archive_bytes)
+
+    shutil.rmtree("packages/testpkg")
+    shutil.rmtree("_archives")


### PR DESCRIPTION
Store archive sizes in imported package metadata and show them in
automatic pull request comments.

Used Codex to implement the metadata and PR comment changes.

Co-authored-by: Codex <codex@openai.com>
