### PR TITLE
ci: notify about new regressions

### DIFF
--- a/.github/workflows/update-latest-report.yml
+++ b/.github/workflows/update-latest-report.yml
@@ -25,10 +25,16 @@ on:
         type: string
         default: master  # or 4.11.1 or ...
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   update-latest:
     name: "Upload report"
     runs-on: ubuntu-slim
+    env:
+      CI_REGRESSION_MENTIONS: "@fingolfin"
     steps:
       - name: "Set up Python"
         uses: actions/setup-python@v6
@@ -55,10 +61,21 @@ jobs:
           git branch --track gh-pages origin/gh-pages
           git worktree add gh-pages gh-pages
 
+      - name: "Capture previous report status"
+        run: |
+          PREVIOUS="data/reports/latest-${{ github.event.inputs.which-gap || inputs.which-gap }}/test-status.json"
+          if [ -f "${PREVIOUS}" ]; then
+            jq '.pkgs | with_entries(.value = .value.status)' "${PREVIOUS}" > _previous-statuses.json
+          else
+            echo '{}' > _previous-statuses.json
+          fi
+
       - name: "Update latest report"
+        id: update-latest-report
         run: |
           ROOT="data/reports"
           DIR_REL=$(jq -r '.id' < '_report/test-status.json')
+          echo "dir_rel=${DIR_REL}" >> "$GITHUB_OUTPUT"
           DIR="${ROOT}/${DIR_REL}"
           mkdir -p ${DIR}
           mv _report/* ${DIR}
@@ -78,3 +95,16 @@ jobs:
           git add -A
           git commit -m "Automated redirect for ${{ github.event.inputs.which-gap || inputs.which-gap }}"
           git pull --rebase && git push
+
+      - name: "Notify CI regressions"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python tools/notify_ci_regressions.py \
+            "${GITHUB_TOKEN}" \
+            "${GITHUB_REPOSITORY}" \
+            "${{ github.event.inputs.which-gap || inputs.which-gap }}" \
+            "${CI_REGRESSION_MENTIONS}" \
+            "data/reports/${{ steps.update-latest-report.outputs.dir_rel }}/test-status.json" \
+            "data/reports/${{ steps.update-latest-report.outputs.dir_rel }}/test-status-diff.json" \
+            "_previous-statuses.json"

--- a/tools/notify_ci_regressions.py
+++ b/tools/notify_ci_regressions.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+
+#############################################################################
+##
+##  This file is part of GAP, a system for computational discrete algebra.
+##
+##  Copyright of GAP belongs to its developers, whose names are too numerous
+##  to list here. Please refer to the COPYRIGHT file for details.
+##
+##  SPDX-License-Identifier: GPL-2.0-or-later
+##
+
+import json
+import sys
+from typing import Any
+
+import requests
+
+ISSUE_LABEL = "ci-regression"
+ISSUE_TITLE_PREFIX = "CI regression:"
+
+
+def load_json(path: str) -> dict[str, Any]:
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def github_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+
+
+def changed_failures(
+    test_status: dict[str, Any], previous_statuses: dict[str, str]
+) -> list[dict[str, str]]:
+    rows = []
+    for pkg, data in sorted(test_status["pkgs"].items()):
+        previous = previous_statuses.get(pkg)
+        if data["status"] == "failure" and previous != "failure":
+            rows.append(
+                {
+                    "name": pkg,
+                    "version": data["version"],
+                    "job_url": data["workflow_run"],
+                    "previous_status": previous or "missing",
+                }
+            )
+    return rows
+
+
+def format_package_lines(rows: list[dict[str, str]]) -> str:
+    return "\n".join(
+        f"- {row['name']} {row['version']} ([failure]({row['job_url']}))"
+        for row in rows
+    )
+
+
+def render_issue_body(
+    which_gap: str,
+    workflow_url: str,
+    report_url: str,
+    report_id: str,
+    rows: list[dict[str, str]],
+    mentions: list[str] | None = None,
+) -> str:
+    body = (
+        f"Detected new package regressions on GAP `{which_gap}`.\n\n"
+        f"Report id: `{report_id}`\n\n"
+        f"Workflow: {workflow_url}\n\n"
+        f"Report: {report_url}\n\n"
+        f"New failures:\n{format_package_lines(rows)}\n\n"
+    )
+    if mentions:
+        body += f"{' '.join(mentions)}\n"
+    return body
+
+
+def render_issue_comment(
+    which_gap: str,
+    workflow_url: str,
+    report_url: str,
+    report_id: str,
+    rows: list[dict[str, str]],
+) -> str:
+    return (
+        f"New regression event detected on GAP `{which_gap}`.\n\n"
+        f"Report id: `{report_id}`\n\n"
+        f"Workflow: {workflow_url}\n\n"
+        f"Report: {report_url}\n\n"
+        f"New failures:\n{format_package_lines(rows)}\n"
+    )
+
+
+def find_open_incident_issue(
+    session: requests.Session, repo: str, token: str
+) -> dict[str, Any] | None:
+    url = f"https://api.github.com/repos/{repo}/issues"
+    params: dict[str, str] = {
+        "state": "open",
+        "labels": ISSUE_LABEL,
+        "per_page": "100",
+    }
+    res = session.get(
+        url,
+        headers=github_headers(token),
+        params=params,
+    )
+    res.raise_for_status()
+    for issue in res.json():
+        if issue["title"].startswith(ISSUE_TITLE_PREFIX):
+            return issue
+    return None
+
+
+def run_notification(
+    session: requests.Session,
+    repo: str,
+    token: str,
+    which_gap: str,
+    mentions: list[str],
+    test_status: dict[str, Any],
+    report_diff: dict[str, Any],
+    previous_statuses: dict[str, str] | None = None,
+    report_url: str | None = None,
+) -> dict[str, Any]:
+    if report_diff.get("failure_changed", 0) <= 0:
+        return {"action": "noop", "issue_number": None}
+
+    rows = changed_failures(test_status, previous_statuses or {})
+    workflow_url = test_status["workflow"]
+    issue = find_open_incident_issue(session, repo, token)
+    title = f"{ISSUE_TITLE_PREFIX} packages now failing on GAP {which_gap}"
+    if issue is None:
+        body = render_issue_body(
+            which_gap,
+            workflow_url,
+            report_url or workflow_url,
+            test_status["id"],
+            rows,
+            mentions,
+        )
+        res = session.post(
+            f"https://api.github.com/repos/{repo}/issues",
+            headers=github_headers(token),
+            json={"title": title, "labels": [ISSUE_LABEL], "body": body},
+        )
+        res.raise_for_status()
+        created = res.json()
+        return {"action": "created", "issue_number": created["number"]}
+
+    body = render_issue_body(
+        which_gap,
+        workflow_url,
+        report_url or workflow_url,
+        test_status["id"],
+        rows,
+    )
+    res = session.patch(
+        f"https://api.github.com/repos/{repo}/issues/{issue['number']}",
+        headers=github_headers(token),
+        json={"title": title, "body": body},
+    )
+    res.raise_for_status()
+    res = session.post(
+        f"https://api.github.com/repos/{repo}/issues/{issue['number']}/comments",
+        headers=github_headers(token),
+        json={
+            "body": render_issue_comment(
+                which_gap,
+                workflow_url,
+                report_url or workflow_url,
+                test_status["id"],
+                rows,
+            )
+        },
+    )
+    res.raise_for_status()
+    return {"action": "updated", "issue_number": issue["number"]}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 8:
+        raise SystemExit(
+            "usage: notify_ci_regressions.py TOKEN REPO WHICH_GAP "
+            "MENTIONS TEST_STATUS REPORT_DIFF PREVIOUS_STATUS"
+        )
+
+    (
+        token,
+        repo,
+        which_gap,
+        mentions_arg,
+        test_status_path,
+        report_diff_path,
+        previous_path,
+    ) = argv[1:8]
+    mentions = [entry for entry in mentions_arg.split(",") if entry]
+    test_status = load_json(test_status_path)
+    report_diff = load_json(report_diff_path)
+    previous_statuses = load_json(previous_path)
+    report_url = (
+        f"{test_status['repo']}/blob/data/reports/{test_status['id']}/report.md"
+    )
+    session = requests.Session()
+    result = run_notification(
+        session=session,
+        repo=repo,
+        token=token,
+        which_gap=which_gap,
+        mentions=mentions,
+        test_status=test_status,
+        report_diff=report_diff,
+        previous_statuses=previous_statuses,
+        report_url=report_url,
+    )
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/tests/test_notify_ci_regressions.py
+++ b/tools/tests/test_notify_ci_regressions.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-function-docstring, invalid-name
+
+import importlib
+import os
+import sys
+
+sys.path.insert(
+    0, "/".join(os.path.dirname(os.path.realpath(__file__)).split("/")[:-1])
+)
+
+
+def test_run_returns_without_api_calls_when_no_new_failures():
+    module = importlib.import_module("notify_ci_regressions")
+    calls = []
+
+    class Session:
+        def get(self, *args, **kwargs):
+            calls.append(("get", args, kwargs))
+            raise AssertionError("GitHub API should not be queried")
+
+        def post(self, *args, **kwargs):
+            calls.append(("post", args, kwargs))
+            raise AssertionError("GitHub API should not be queried")
+
+        def patch(self, *args, **kwargs):
+            calls.append(("patch", args, kwargs))
+            raise AssertionError("GitHub API should not be queried")
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/1",
+            "id": "master/2026-04-24-abcdef12",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "success",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                }
+            },
+        },
+        report_diff={"failure_changed": 0},
+    )
+
+    assert result == {"action": "noop", "issue_number": None}
+    assert calls == []
+
+
+def test_run_creates_incident_issue_with_mentions_for_first_regression():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            assert url.endswith("/repos/gap-system/PackageDistro/issues")
+            assert params["state"] == "open"
+            assert params["labels"] == "ci-regression"
+            return Response([])
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            return Response({"number": 4021})
+
+        def patch(self, *args, **kwargs):
+            raise AssertionError("patch should not be called")
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/9",
+            "id": "master/2026-04-24-abcdef12",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "failure",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                },
+                "guava": {
+                    "status": "success",
+                    "version": "3.0",
+                    "workflow_run": "https://example.invalid/job/guava",
+                },
+            },
+        },
+        report_diff={"failure_changed": 1},
+        previous_statuses={"atlasrep": "success", "guava": "success"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "created", "issue_number": 4021}
+    body = seen["posts"][0][1]["body"]
+    assert "@user1 @user2" in body
+    assert "atlasrep 2.1" in body
+    assert (
+        "CI regression: packages now failing on GAP master"
+        == seen["posts"][0][1]["title"]
+    )
+
+
+def test_run_updates_existing_incident_and_comments_without_mentions():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"patches": [], "posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            return Response(
+                [
+                    {
+                        "number": 7550,
+                        "title": "CI regression: packages now failing on GAP master",
+                        "labels": [{"name": "ci-regression"}],
+                    }
+                ]
+            )
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            return Response({"id": 1})
+
+        def patch(self, url, headers=None, json=None):
+            seen["patches"].append((url, json))
+            return Response({"number": 7550})
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/10",
+            "id": "master/2026-04-25-fedcba98",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "failure",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                }
+            },
+        },
+        report_diff={"failure_changed": 1},
+        previous_statuses={"atlasrep": "success"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "updated", "issue_number": 7550}
+    assert "@user1" not in seen["posts"][0][1]["body"]
+    assert "@user1" not in seen["patches"][0][1]["body"]
+    assert "atlasrep 2.1" in seen["patches"][0][1]["body"]


### PR DESCRIPTION
Add a workflow helper that opens or updates a labeled GitHub incident issue when the daily report detects newly failing packages. The reporting workflow now snapshots the previous latest status and calls the helper after publishing the refreshed report.

AI assistance disclosure: Codex helped design, implement, and test the GitHub-native CI regression notification workflow and helper script.

Co-authored-by: Codex <codex@openai.com>

Closes #402
Closes #755
