### PR TITLE
ci: Skip scheduled workflows in forks

### DIFF
--- a/.github/workflows/scan-for-updates.yml
+++ b/.github/workflows/scan-for-updates.yml
@@ -22,8 +22,27 @@ on:
     - cron: '3 * * * *' # Every hours at 3 past
 
 jobs:
+  check-schedule-scope:
+    name: "Check whether this workflow should run"
+    runs-on: ubuntu-slim
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: "Decide whether to continue"
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" != "schedule" ]] || \
+             [[ "${{ github.repository }}" == "gap-system/PackageDistro" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "Skipping scheduled run outside gap-system/PackageDistro."
+          fi
+
   scan-for-updates:
     name: "Scan for package updates"
+    needs: check-schedule-scope
+    if: ${{ needs.check-schedule-scope.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-names.outputs.matrix }}
@@ -112,8 +131,10 @@ jobs:
 
   create-pull-request:
     name: "Create pull request for ${{ matrix.package_or_group }}"
-    if: ${{ needs.scan-for-updates.outputs.matrix != '{"package_or_group":[]}' }}
-    needs: scan-for-updates
+    if: ${{ needs.check-schedule-scope.outputs.should_run == 'true' && needs.scan-for-updates.outputs.matrix != '{"package_or_group":[]}' }}
+    needs:
+      - check-schedule-scope
+      - scan-for-updates
     runs-on: ubuntu-slim
     strategy:
       fail-fast: false

--- a/.github/workflows/test-all-and-report.yml
+++ b/.github/workflows/test-all-and-report.yml
@@ -25,19 +25,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-schedule-scope:
+    name: "Check whether this workflow should run"
+    runs-on: ubuntu-slim
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: "Decide whether to continue"
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" != "schedule" ]] || \
+             [[ "${{ github.repository }}" == "gap-system/PackageDistro" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "Skipping scheduled run outside gap-system/PackageDistro."
+          fi
+
   # GAP master branch
   test-all-master:
     # If you change this name, you must adjust the corresponding prefix
     # in the step of test-all.yml that calls tools/generate_test_status.py
     name: "master"
+    needs: check-schedule-scope
+    if: ${{ needs.check-schedule-scope.outputs.should_run == 'true' }}
     uses: ./.github/workflows/test-all.yml
     with:
       which-gap: master
 
   update-latest-master:
     name: "Upload master report"
-    needs: test-all-master
-    if: always()
+    needs:
+      - check-schedule-scope
+      - test-all-master
+    if: ${{ always() && needs.check-schedule-scope.outputs.should_run == 'true' }}
     uses: ./.github/workflows/update-latest-report.yml
     with:
       which-gap: master


### PR DESCRIPTION
Add a gate job to the scheduled workflows so scheduled runs stop
early in forks while workflow_dispatch and push runs keep working
as before.

Resolves #320

AI assistance: Codex prepared the workflow changes and verified
the YAML updates.

Co-authored-by: Codex <codex@openai.com>
