### PR TITLE
ci: track regression issue lifecycle

### DIFF
--- a/docs/superpowers/plans/2026-05-06-ci-regression-issue-lifecycle.md
+++ b/docs/superpowers/plans/2026-05-06-ci-regression-issue-lifecycle.md
@@ -1,0 +1,558 @@
+# CI Regression Issue Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the CI regression notifier keep one live incident issue in sync with the current failing package set and close it automatically once the latest `master` report is fully green.
+
+**Architecture:** Extend `tools/notify_ci_regressions.py` so it computes both the current failing package set and the newly introduced failing package set, then routes create, update, comment, close, and no-op behavior through one control flow. Keep the GitHub Actions workflow interface unchanged and drive the behavior with focused tests in `tools/tests/test_notify_ci_regressions.py`.
+
+**Tech Stack:** Python 3, `requests`, `pytest`, GitHub Issues REST API
+
+---
+
+### Task 1: Cover persistent issue updates in tests
+
+**Files:**
+- Modify: `tools/tests/test_notify_ci_regressions.py`
+- Modify: `tools/notify_ci_regressions.py`
+- Test: `tools/tests/test_notify_ci_regressions.py`
+
+- [ ] **Step 1: Write the failing test for updating an existing issue when failures persist but no new regression was introduced**
+
+```python
+def test_run_updates_existing_incident_for_current_failures_without_comment():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"patches": [], "posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            return Response(
+                [
+                    {
+                        "number": 7550,
+                        "title": "CI regression: packages now failing on GAP master",
+                        "labels": [{"name": "ci-regression"}],
+                    }
+                ]
+            )
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            raise AssertionError("post should not be called")
+
+        def patch(self, url, headers=None, json=None):
+            seen["patches"].append((url, json))
+            return Response({"number": 7550})
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/10",
+            "id": "master/2026-04-25-fedcba98",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "failure",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                },
+                "guava": {
+                    "status": "failure",
+                    "version": "3.0",
+                    "workflow_run": "https://example.invalid/job/guava",
+                },
+            },
+        },
+        report_diff={"failure_changed": 0},
+        previous_statuses={"atlasrep": "failure", "guava": "failure"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "updated", "issue_number": 7550}
+    assert len(seen["patches"]) == 1
+    assert "atlasrep 2.1" in seen["patches"][0][1]["body"]
+    assert "guava 3.0" in seen["patches"][0][1]["body"]
+    assert seen["posts"] == []
+```
+
+- [ ] **Step 2: Run the new test and verify it fails against the current notifier**
+
+Run: `python -m pytest tools/tests/test_notify_ci_regressions.py -k current_failures_without_comment -vv`
+Expected: FAIL because `run_notification` currently returns `{"action": "noop", "issue_number": None}` when `failure_changed` is `0`.
+
+- [ ] **Step 3: Implement current-failure tracking and unconditional issue body refresh when failures remain**
+
+```python
+def current_failures(test_status: dict[str, Any]) -> list[dict[str, str]]:
+    rows = []
+    for pkg, data in sorted(test_status["pkgs"].items()):
+        if data["status"] == "failure":
+            rows.append(
+                {
+                    "name": pkg,
+                    "version": data["version"],
+                    "job_url": data["workflow_run"],
+                }
+            )
+    return rows
+
+
+def run_notification(
+    session: requests.Session,
+    repo: str,
+    token: str,
+    which_gap: str,
+    mentions: list[str],
+    test_status: dict[str, Any],
+    report_diff: dict[str, Any],
+    previous_statuses: dict[str, str] | None = None,
+    report_url: str | None = None,
+) -> dict[str, Any]:
+    current_rows = current_failures(test_status)
+    changed_rows = changed_failures(test_status, previous_statuses or {})
+    workflow_url = test_status["workflow"]
+    issue = find_open_incident_issue(session, repo, token)
+    title = f"{ISSUE_TITLE_PREFIX} packages now failing on GAP {which_gap}"
+
+    if not current_rows:
+        return {"action": "noop", "issue_number": None}
+
+    body = render_issue_body(
+        which_gap,
+        workflow_url,
+        report_url or workflow_url,
+        test_status["id"],
+        current_rows,
+        mentions if issue is None else None,
+    )
+
+    if issue is None:
+        res = session.post(
+            f"https://api.github.com/repos/{repo}/issues",
+            headers=github_headers(token),
+            json={"title": title, "labels": [ISSUE_LABEL], "body": body},
+        )
+        res.raise_for_status()
+        created = res.json()
+        return {"action": "created", "issue_number": created["number"]}
+
+    session.patch(
+        f"https://api.github.com/repos/{repo}/issues/{issue['number']}",
+        headers=github_headers(token),
+        json={"title": title, "body": body},
+    ).raise_for_status()
+
+    if changed_rows:
+        session.post(
+            f"https://api.github.com/repos/{repo}/issues/{issue['number']}/comments",
+            headers=github_headers(token),
+            json={
+                "body": render_issue_comment(
+                    which_gap,
+                    workflow_url,
+                    report_url or workflow_url,
+                    test_status["id"],
+                    changed_rows,
+                )
+            },
+        ).raise_for_status()
+
+    return {"action": "updated", "issue_number": issue["number"]}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run: `python -m pytest tools/tests/test_notify_ci_regressions.py -k current_failures_without_comment -vv`
+Expected: PASS
+
+- [ ] **Step 5: Commit the progress**
+
+```bash
+git add tools/tests/test_notify_ci_regressions.py tools/notify_ci_regressions.py
+git commit -m "ci: keep regression issue current" -m "Update the open CI regression issue whenever failures remain on GAP master, even when the latest run introduced no new failures." -m "This keeps the incident issue body aligned with the current failing package set instead of leaving stale package lists behind." -m "AI-assisted by Codex for implementation planning and code changes." -m "Co-authored-by: Codex <codex@openai.com>"
+```
+
+### Task 2: Cover comments for newly introduced failures and preserve current-body semantics
+
+**Files:**
+- Modify: `tools/tests/test_notify_ci_regressions.py`
+- Modify: `tools/notify_ci_regressions.py`
+- Test: `tools/tests/test_notify_ci_regressions.py`
+
+- [ ] **Step 1: Adjust the existing update test so it proves both current-body refresh and new-regression commenting**
+
+```python
+def test_run_updates_existing_incident_and_comments_without_mentions():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"patches": [], "posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            return Response(
+                [
+                    {
+                        "number": 7550,
+                        "title": "CI regression: packages now failing on GAP master",
+                        "labels": [{"name": "ci-regression"}],
+                    }
+                ]
+            )
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            return Response({"id": 1})
+
+        def patch(self, url, headers=None, json=None):
+            seen["patches"].append((url, json))
+            return Response({"number": 7550})
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/10",
+            "id": "master/2026-04-25-fedcba98",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "failure",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                },
+                "guava": {
+                    "status": "failure",
+                    "version": "3.0",
+                    "workflow_run": "https://example.invalid/job/guava",
+                },
+            },
+        },
+        report_diff={"failure_changed": 1},
+        previous_statuses={"atlasrep": "failure", "guava": "success"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "updated", "issue_number": 7550}
+    assert "atlasrep 2.1" in seen["patches"][0][1]["body"]
+    assert "guava 3.0" in seen["patches"][0][1]["body"]
+    assert "guava 3.0" in seen["posts"][0][1]["body"]
+    assert "@user1" not in seen["patches"][0][1]["body"]
+    assert "@user1" not in seen["posts"][0][1]["body"]
+```
+
+- [ ] **Step 2: Run the focused tests and verify the updated expectations fail if the notifier still writes only newly failing packages into the issue body**
+
+Run: `python -m pytest tools/tests/test_notify_ci_regressions.py -k "updates_existing_incident" -vv`
+Expected: FAIL until the issue body uses the full current failing package set while the comment continues to describe only the newly introduced failures.
+
+- [ ] **Step 3: Update body/comment rendering so the issue body lists all current failures and the comment lists only newly introduced failures**
+
+```python
+def render_issue_body(
+    which_gap: str,
+    workflow_url: str,
+    report_url: str,
+    report_id: str,
+    rows: list[dict[str, str]],
+    mentions: list[str] | None = None,
+) -> str:
+    body = (
+        f"Current package failures on GAP `{which_gap}`.\n\n"
+        f"Report id: `{report_id}`\n\n"
+        f"Workflow: {workflow_url}\n\n"
+        f"Report: {report_url}\n\n"
+        f"Current failures:\n{format_package_lines(rows)}\n\n"
+    )
+    if mentions:
+        body += f"{' '.join(mentions)}\n"
+    return body
+
+
+def render_issue_comment(...):
+    return (
+        f"New regression event detected on GAP `{which_gap}`.\n\n"
+        f"Report id: `{report_id}`\n\n"
+        f"Workflow: {workflow_url}\n\n"
+        f"Report: {report_url}\n\n"
+        f"New failures:\n{format_package_lines(rows)}\n"
+    )
+```
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+Run: `python -m pytest tools/tests/test_notify_ci_regressions.py -k "updates_existing_incident" -vv`
+Expected: PASS
+
+- [ ] **Step 5: Commit the progress**
+
+```bash
+git add tools/tests/test_notify_ci_regressions.py tools/notify_ci_regressions.py
+git commit -m "ci: separate current and new failures" -m "Render the regression issue body from the full current failing package set while keeping update comments scoped to newly introduced failures." -m "This preserves incident history in comments without making the live issue description drift from the latest report." -m "AI-assisted by Codex for implementation planning and code changes." -m "Co-authored-by: Codex <codex@openai.com>"
+```
+
+### Task 3: Close the incident issue when the latest report is fully green
+
+**Files:**
+- Modify: `tools/tests/test_notify_ci_regressions.py`
+- Modify: `tools/notify_ci_regressions.py`
+- Test: `tools/tests/test_notify_ci_regressions.py`
+
+- [ ] **Step 1: Write the failing tests for the green-report cases**
+
+```python
+def test_run_returns_without_api_calls_when_no_failures_and_no_issue():
+    module = importlib.import_module("notify_ci_regressions")
+    calls = []
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            calls.append(("get", url, params))
+            return Response([])
+
+        def post(self, *args, **kwargs):
+            calls.append(("post", args, kwargs))
+            raise AssertionError("GitHub API should not be queried")
+
+        def patch(self, *args, **kwargs):
+            calls.append(("patch", args, kwargs))
+            raise AssertionError("GitHub API should not be queried")
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/1",
+            "id": "master/2026-04-24-abcdef12",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "success",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                }
+            },
+        },
+        report_diff={"failure_changed": 0},
+    )
+
+    assert result == {"action": "noop", "issue_number": None}
+    assert calls == [
+        (
+            "get",
+            "https://api.github.com/repos/gap-system/PackageDistro/issues",
+            {"state": "open", "labels": "ci-regression", "per_page": "100"},
+        )
+    ]
+
+
+def test_run_closes_existing_incident_when_failures_clear():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"patches": [], "posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            return Response(
+                [
+                    {
+                        "number": 7550,
+                        "title": "CI regression: packages now failing on GAP master",
+                        "labels": [{"name": "ci-regression"}],
+                    }
+                ]
+            )
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            return Response({"id": 1})
+
+        def patch(self, url, headers=None, json=None):
+            seen["patches"].append((url, json))
+            return Response({"number": 7550, "state": "closed"})
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/11",
+            "id": "master/2026-04-26-01234567",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "success",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                }
+            },
+        },
+        report_diff={"failure_changed": -1},
+        previous_statuses={"atlasrep": "failure"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "closed", "issue_number": 7550}
+    assert "fully passing" in seen["posts"][0][1]["body"]
+    assert seen["patches"][0][1]["state"] == "closed"
+```
+
+- [ ] **Step 2: Run the green-report tests and verify the close path fails before implementation**
+
+Run: `python -m pytest tools/tests/test_notify_ci_regressions.py -k "no_failures or closes_existing_incident" -vv`
+Expected: FAIL because the current notifier exits early or never closes an existing issue.
+
+- [ ] **Step 3: Implement the no-failure branch that comments on and closes an open incident**
+
+```python
+def render_resolution_comment(
+    which_gap: str,
+    workflow_url: str,
+    report_url: str,
+    report_id: str,
+) -> str:
+    return (
+        f"Latest report for GAP `{which_gap}` is now fully passing.\n\n"
+        f"Report id: `{report_id}`\n\n"
+        f"Workflow: {workflow_url}\n\n"
+        f"Report: {report_url}\n"
+    )
+
+
+def run_notification(
+    session: requests.Session,
+    repo: str,
+    token: str,
+    which_gap: str,
+    mentions: list[str],
+    test_status: dict[str, Any],
+    report_diff: dict[str, Any],
+    previous_statuses: dict[str, str] | None = None,
+    report_url: str | None = None,
+) -> dict[str, Any]:
+    current_rows = current_failures(test_status)
+    changed_rows = changed_failures(test_status, previous_statuses or {})
+    workflow_url = test_status["workflow"]
+    issue = find_open_incident_issue(session, repo, token)
+    if not current_rows:
+        if issue is None:
+            return {"action": "noop", "issue_number": None}
+        session.post(
+            f"https://api.github.com/repos/{repo}/issues/{issue['number']}/comments",
+            headers=github_headers(token),
+            json={
+                "body": render_resolution_comment(
+                    which_gap,
+                    workflow_url,
+                    report_url or workflow_url,
+                    test_status["id"],
+                )
+            },
+        ).raise_for_status()
+        session.patch(
+            f"https://api.github.com/repos/{repo}/issues/{issue['number']}",
+            headers=github_headers(token),
+            json={"state": "closed"},
+        ).raise_for_status()
+        return {"action": "closed", "issue_number": issue["number"]}
+```
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+Run: `python -m pytest tools/tests/test_notify_ci_regressions.py -k "no_failures or closes_existing_incident" -vv`
+Expected: PASS
+
+- [ ] **Step 5: Commit the progress**
+
+```bash
+git add tools/tests/test_notify_ci_regressions.py tools/notify_ci_regressions.py
+git commit -m "ci: close resolved regression issues" -m "Close the live CI regression incident after the latest GAP master report becomes fully green, and leave a resolution comment with links back to the report and workflow." -m "This prevents intermittent failures from leaving stale open incidents behind after the next clean run." -m "AI-assisted by Codex for implementation planning and code changes." -m "Co-authored-by: Codex <codex@openai.com>"
+```
+
+### Task 4: Run the full notifier test suite and project Python checks
+
+**Files:**
+- Modify: `tools/notify_ci_regressions.py`
+- Modify: `tools/tests/test_notify_ci_regressions.py`
+- Test: `tools/tests/test_notify_ci_regressions.py`
+
+- [ ] **Step 1: Run the notifier test file**
+
+Run: `python -m pytest tools/tests/test_notify_ci_regressions.py -vv`
+Expected: PASS with all notifier lifecycle tests green.
+
+- [ ] **Step 2: Run formatting and type checks relevant to Python tooling**
+
+Run: `python -m black --check --diff tools`
+Expected: PASS
+
+Run: `python -m isort --check --profile black tools`
+Expected: PASS
+
+Run: `python -m mypy --disallow-untyped-calls --disallow-untyped-defs tools/*.py`
+Expected: PASS
+
+- [ ] **Step 3: Run the broader Python test suite because the notifier lives in shared tooling**
+
+Run: `python -m pytest tools/tests/test*.py -vv`
+Expected: PASS
+
+- [ ] **Step 4: Review whether `CHANGELOG.md` needs an entry**
+
+Check whether this repository has a changelog file that should be updated for the CI behavior change. If one exists and project policy expects an entry, add it in the implementation branch before the final commit.
+
+- [ ] **Step 5: Commit any final polish**
+
+```bash
+git add tools/notify_ci_regressions.py tools/tests/test_notify_ci_regressions.py
+git commit -m "ci: finalize regression issue lifecycle" -m "Run the notifier through the project Python checks and keep the workflow interface unchanged while the issue lifecycle now covers create, refresh, comment, and close behavior." -m "AI-assisted by Codex for implementation planning and code changes." -m "Co-authored-by: Codex <codex@openai.com>"
+```

--- a/docs/superpowers/specs/2026-05-06-ci-regression-issue-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-06-ci-regression-issue-lifecycle-design.md
@@ -1,0 +1,101 @@
+# CI Regression Issue Lifecycle Design
+
+## Summary
+
+Keep a single open `ci-regression` issue as the live incident record for
+package test failures on GAP `main`/`master`. The issue body should always
+describe the current failing package set. The issue should be closed
+automatically once the latest report for `main`/`master` contains no failing
+packages.
+
+## Scope
+
+This change only affects the regression notifier used by
+`.github/workflows/update-latest-report.yml` and its tests in `tools/tests`.
+It does not change how reports are generated, how package status diffs are
+computed, or how non-`main`/`master` workflows behave.
+
+## Current Behavior
+
+`tools/notify_ci_regressions.py` only reacts when the diff report says a new
+failure appeared. In that case it creates or updates an open
+`ci-regression` issue and may add a comment describing the new regression
+event. If later runs still contain failures but no newly introduced failure,
+the script exits without touching the issue. It also never closes the issue
+when all failures disappear.
+
+## Desired Behavior
+
+The `ci-regression` issue should represent the current incident state for the
+latest `main`/`master` report.
+
+- If the latest report contains at least one failing package and no incident
+  issue is open, create one.
+- If the latest report contains at least one failing package and an incident
+  issue is already open, update the issue title and body so they match the
+  current failing package set.
+- If the latest run introduces one or more newly failing packages compared to
+  the previous report, add a comment describing that regression event.
+- If the latest report contains no failing packages and an incident issue is
+  open, add a short resolution comment and close the issue.
+- If the latest report contains no failing packages and no incident issue is
+  open, do nothing.
+
+## Data Sources
+
+- `test-status.json` remains the source of truth for the current package
+  status set.
+- `test-status-diff.json` remains the source of truth for whether the current
+  run introduced new failures and therefore merits an additional comment.
+- `_previous-statuses.json` remains the source used to identify which
+  packages are newly failing.
+
+The implementation must not infer current failures from the diff file alone.
+
+## Script Changes
+
+`tools/notify_ci_regressions.py` should be extended so that its main control
+flow first computes the full list of currently failing packages, then branches
+based on two facts:
+
+1. whether an incident issue is currently open; and
+2. whether the latest report still contains any failures.
+
+The script should keep the current title format and issue label. The issue
+body format may continue to list the workflow URL, report URL, report id, and
+failing packages. The body content for an open issue must always reflect the
+current failures, not only the newest ones.
+
+When closing an issue, the script should post a brief comment that the latest
+`main`/`master` report is fully passing and include the workflow and report
+links used for resolution.
+
+## Workflow Changes
+
+The workflow contract does not need to change. The existing
+`Notify CI regressions` step in
+`.github/workflows/update-latest-report.yml` should continue to invoke the
+same script with the same inputs. The behavior change should be entirely
+inside the Python notifier.
+
+## Testing
+
+Update `tools/tests/test_notify_ci_regressions.py` to cover these cases:
+
+- no failures and no open incident issue: no API writes;
+- first failure set creates a new issue with mentions;
+- existing incident issue is updated when the current failing package set
+  changes, even if the diff reports no newly introduced failure;
+- existing incident issue is updated and commented when new failures are
+  introduced;
+- existing incident issue is commented on and closed when the report becomes
+  fully green.
+
+The tests should keep using stub `Session` objects and should verify the
+GitHub API methods, payloads, and resulting action summary.
+
+## Error Handling
+
+Retain the current `requests` error handling style: GitHub API responses
+should still be checked via `raise_for_status()`. No retry logic is needed in
+this change.

--- a/tools/notify_ci_regressions.py
+++ b/tools/notify_ci_regressions.py
@@ -50,6 +50,20 @@ def changed_failures(
     return rows
 
 
+def current_failures(test_status: dict[str, Any]) -> list[dict[str, str]]:
+    rows = []
+    for pkg, data in sorted(test_status["pkgs"].items()):
+        if data["status"] == "failure":
+            rows.append(
+                {
+                    "name": pkg,
+                    "version": data["version"],
+                    "job_url": data["workflow_run"],
+                }
+            )
+    return rows
+
+
 def format_package_lines(rows: list[dict[str, str]]) -> str:
     return "\n".join(
         f"- {row['name']} {row['version']} ([failure]({row['job_url']}))"
@@ -66,11 +80,11 @@ def render_issue_body(
     mentions: list[str] | None = None,
 ) -> str:
     body = (
-        f"Detected new package regressions on GAP `{which_gap}`.\n\n"
+        f"Current package failures on GAP `{which_gap}`.\n\n"
         f"Report id: `{report_id}`\n\n"
         f"Workflow: {workflow_url}\n\n"
         f"Report: {report_url}\n\n"
-        f"New failures:\n{format_package_lines(rows)}\n\n"
+        f"Current failures:\n{format_package_lines(rows)}\n\n"
     )
     if mentions:
         body += f"{' '.join(mentions)}\n"
@@ -93,8 +107,22 @@ def render_issue_comment(
     )
 
 
+def render_resolution_comment(
+    which_gap: str,
+    workflow_url: str,
+    report_url: str,
+    report_id: str,
+) -> str:
+    return (
+        f"Latest report for GAP `{which_gap}` is now fully passing.\n\n"
+        f"Report id: `{report_id}`\n\n"
+        f"Workflow: {workflow_url}\n\n"
+        f"Report: {report_url}\n"
+    )
+
+
 def find_open_incident_issue(
-    session: requests.Session, repo: str, token: str
+    session: requests.Session, repo: str, token: str, which_gap: str
 ) -> dict[str, Any] | None:
     url = f"https://api.github.com/repos/{repo}/issues"
     params: dict[str, str] = {
@@ -102,6 +130,7 @@ def find_open_incident_issue(
         "labels": ISSUE_LABEL,
         "per_page": "100",
     }
+    expected_title = f"{ISSUE_TITLE_PREFIX} packages now failing on GAP {which_gap}"
     res = session.get(
         url,
         headers=github_headers(token),
@@ -109,7 +138,7 @@ def find_open_incident_issue(
     )
     res.raise_for_status()
     for issue in res.json():
-        if issue["title"].startswith(ISSUE_TITLE_PREFIX):
+        if issue["title"] == expected_title:
             return issue
     return None
 
@@ -125,12 +154,34 @@ def run_notification(
     previous_statuses: dict[str, str] | None = None,
     report_url: str | None = None,
 ) -> dict[str, Any]:
-    if report_diff.get("failure_changed", 0) <= 0:
-        return {"action": "noop", "issue_number": None}
-
-    rows = changed_failures(test_status, previous_statuses or {})
+    current_rows = current_failures(test_status)
     workflow_url = test_status["workflow"]
-    issue = find_open_incident_issue(session, repo, token)
+    issue = find_open_incident_issue(session, repo, token, which_gap)
+    if not current_rows:
+        if issue is None:
+            return {"action": "noop", "issue_number": None}
+        res = session.post(
+            f"https://api.github.com/repos/{repo}/issues/{issue['number']}/comments",
+            headers=github_headers(token),
+            json={
+                "body": render_resolution_comment(
+                    which_gap,
+                    workflow_url,
+                    report_url or workflow_url,
+                    test_status["id"],
+                )
+            },
+        )
+        res.raise_for_status()
+        res = session.patch(
+            f"https://api.github.com/repos/{repo}/issues/{issue['number']}",
+            headers=github_headers(token),
+            json={"state": "closed"},
+        )
+        res.raise_for_status()
+        return {"action": "closed", "issue_number": issue["number"]}
+
+    changed_rows = changed_failures(test_status, previous_statuses or {})
     title = f"{ISSUE_TITLE_PREFIX} packages now failing on GAP {which_gap}"
     if issue is None:
         body = render_issue_body(
@@ -138,7 +189,7 @@ def run_notification(
             workflow_url,
             report_url or workflow_url,
             test_status["id"],
-            rows,
+            current_rows,
             mentions,
         )
         res = session.post(
@@ -155,7 +206,7 @@ def run_notification(
         workflow_url,
         report_url or workflow_url,
         test_status["id"],
-        rows,
+        current_rows,
     )
     res = session.patch(
         f"https://api.github.com/repos/{repo}/issues/{issue['number']}",
@@ -163,20 +214,21 @@ def run_notification(
         json={"title": title, "body": body},
     )
     res.raise_for_status()
-    res = session.post(
-        f"https://api.github.com/repos/{repo}/issues/{issue['number']}/comments",
-        headers=github_headers(token),
-        json={
-            "body": render_issue_comment(
-                which_gap,
-                workflow_url,
-                report_url or workflow_url,
-                test_status["id"],
-                rows,
-            )
-        },
-    )
-    res.raise_for_status()
+    if changed_rows:
+        res = session.post(
+            f"https://api.github.com/repos/{repo}/issues/{issue['number']}/comments",
+            headers=github_headers(token),
+            json={
+                "body": render_issue_comment(
+                    which_gap,
+                    workflow_url,
+                    report_url or workflow_url,
+                    test_status["id"],
+                    changed_rows,
+                )
+            },
+        )
+        res.raise_for_status()
     return {"action": "updated", "issue_number": issue["number"]}
 
 

--- a/tools/tests/test_notify_ci_regressions.py
+++ b/tools/tests/test_notify_ci_regressions.py
@@ -10,14 +10,25 @@ sys.path.insert(
 )
 
 
-def test_run_returns_without_api_calls_when_no_new_failures():
+def test_run_returns_without_api_calls_when_no_failures_and_no_issue():
     module = importlib.import_module("notify_ci_regressions")
     calls = []
 
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
     class Session:
-        def get(self, *args, **kwargs):
-            calls.append(("get", args, kwargs))
-            raise AssertionError("GitHub API should not be queried")
+        def get(self, url, headers=None, params=None):
+            calls.append(("get", url, params))
+            return Response([])
 
         def post(self, *args, **kwargs):
             calls.append(("post", args, kwargs))
@@ -48,7 +59,155 @@ def test_run_returns_without_api_calls_when_no_new_failures():
     )
 
     assert result == {"action": "noop", "issue_number": None}
-    assert calls == []
+    assert calls == [
+        (
+            "get",
+            "https://api.github.com/repos/gap-system/PackageDistro/issues",
+            {"state": "open", "labels": "ci-regression", "per_page": "100"},
+        )
+    ]
+
+
+def test_run_closes_existing_incident_when_failures_clear():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"patches": [], "posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            return Response(
+                [
+                    {
+                        "number": 7550,
+                        "title": "CI regression: packages now failing on GAP master",
+                        "labels": [{"name": "ci-regression"}],
+                    }
+                ]
+            )
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            return Response({"id": 1})
+
+        def patch(self, url, headers=None, json=None):
+            seen["patches"].append((url, json))
+            return Response({"number": 7550, "state": "closed"})
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/11",
+            "id": "master/2026-04-26-01234567",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "success",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                }
+            },
+        },
+        report_diff={"failure_changed": -1},
+        previous_statuses={"atlasrep": "failure"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "closed", "issue_number": 7550}
+    assert len(seen["posts"]) == 1
+    assert "fully passing" in seen["posts"][0][1]["body"]
+    assert "master/2026-04-26-01234567" in seen["posts"][0][1]["body"]
+    assert (
+        "https://github.com/gap-system/PackageDistro/actions/runs/11"
+        in seen["posts"][0][1]["body"]
+    )
+    assert (
+        "https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md"
+        in seen["posts"][0][1]["body"]
+    )
+    assert seen["patches"][0][1]["state"] == "closed"
+
+
+def test_run_closes_existing_incident_only_for_matching_gap_target():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"patches": [], "posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            return Response(
+                [
+                    {
+                        "number": 7001,
+                        "title": "CI regression: packages now failing on GAP stable-4.14",
+                        "labels": [{"name": "ci-regression"}],
+                    },
+                    {
+                        "number": 7550,
+                        "title": "CI regression: packages now failing on GAP master",
+                        "labels": [{"name": "ci-regression"}],
+                    },
+                ]
+            )
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            return Response({"id": 1})
+
+        def patch(self, url, headers=None, json=None):
+            seen["patches"].append((url, json))
+            return Response({"number": 7550, "state": "closed"})
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/12",
+            "id": "master/2026-04-27-89abcdef",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "success",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                }
+            },
+        },
+        report_diff={"failure_changed": -1},
+        previous_statuses={"atlasrep": "failure"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "closed", "issue_number": 7550}
+    assert len(seen["posts"]) == 1
+    assert "/issues/7550/comments" in seen["posts"][0][0]
+    assert len(seen["patches"]) == 1
+    assert seen["patches"][0][0].endswith("/issues/7550")
+    assert seen["patches"][0][1]["state"] == "closed"
 
 
 def test_run_creates_incident_issue_with_mentions_for_first_regression():
@@ -117,6 +276,76 @@ def test_run_creates_incident_issue_with_mentions_for_first_regression():
     )
 
 
+def test_run_creates_incident_issue_for_current_failures_when_missing():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            return Response(
+                [
+                    {
+                        "number": 7001,
+                        "title": "CI regression: packages now failing on GAP stable-4.14",
+                        "labels": [{"name": "ci-regression"}],
+                    }
+                ]
+            )
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            return Response({"number": 4022})
+
+        def patch(self, *args, **kwargs):
+            raise AssertionError("patch should not be called")
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/13",
+            "id": "master/2026-04-28-a1b2c3d4",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "failure",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                },
+                "guava": {
+                    "status": "failure",
+                    "version": "3.0",
+                    "workflow_run": "https://example.invalid/job/guava",
+                },
+            },
+        },
+        report_diff={"failure_changed": 0},
+        previous_statuses={"atlasrep": "failure", "guava": "failure"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "created", "issue_number": 4022}
+    assert len(seen["posts"]) == 1
+    body = seen["posts"][0][1]["body"]
+    assert "Current package failures on GAP `master`." in body
+    assert "atlasrep 2.1" in body
+    assert "guava 3.0" in body
+    assert "@user1 @user2" in body
+
+
 def test_run_updates_existing_incident_and_comments_without_mentions():
     module = importlib.import_module("notify_ci_regressions")
     seen = {"patches": [], "posts": []}
@@ -166,15 +395,188 @@ def test_run_updates_existing_incident_and_comments_without_mentions():
                     "status": "failure",
                     "version": "2.1",
                     "workflow_run": "https://example.invalid/job/atlasrep",
-                }
+                },
+                "guava": {
+                    "status": "failure",
+                    "version": "3.0",
+                    "workflow_run": "https://example.invalid/job/guava",
+                },
             },
         },
         report_diff={"failure_changed": 1},
-        previous_statuses={"atlasrep": "success"},
+        previous_statuses={"atlasrep": "failure", "guava": "success"},
         report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
     )
 
     assert result == {"action": "updated", "issue_number": 7550}
-    assert "@user1" not in seen["posts"][0][1]["body"]
-    assert "@user1" not in seen["patches"][0][1]["body"]
+    assert len(seen["patches"]) == 1
+    assert len(seen["posts"]) == 1
+    patch_body = seen["patches"][0][1]["body"]
+    assert (
+        seen["posts"][0][0]
+        == "https://api.github.com/repos/gap-system/PackageDistro/issues/7550/comments"
+    )
+    comment_body = seen["posts"][0][1]["body"]
+
+    assert "Current package failures on GAP `master`." in patch_body
+    assert "Current failures:" in patch_body
+    assert "atlasrep 2.1" in patch_body
+    assert "guava 3.0" in patch_body
+
+    assert "New regression event detected on GAP `master`." in comment_body
+    assert "New failures:" in comment_body
+    assert "atlasrep 2.1" not in comment_body
+    assert "guava 3.0" in comment_body
+
+    assert "@user1" not in patch_body
+    assert "@user2" not in patch_body
+    assert "@user1" not in comment_body
+    assert "@user2" not in comment_body
+
+
+def test_run_updates_existing_incident_and_comments_for_mixed_delta():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"patches": [], "posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            return Response(
+                [
+                    {
+                        "number": 7550,
+                        "title": "CI regression: packages now failing on GAP master",
+                        "labels": [{"name": "ci-regression"}],
+                    }
+                ]
+            )
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            return Response({"id": 1})
+
+        def patch(self, url, headers=None, json=None):
+            seen["patches"].append((url, json))
+            return Response({"number": 7550})
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/14",
+            "id": "master/2026-04-29-0badcafe",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "success",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                },
+                "guava": {
+                    "status": "failure",
+                    "version": "3.0",
+                    "workflow_run": "https://example.invalid/job/guava",
+                },
+            },
+        },
+        report_diff={"failure_changed": 0},
+        previous_statuses={"atlasrep": "failure", "guava": "success"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "updated", "issue_number": 7550}
+    assert len(seen["patches"]) == 1
+    assert len(seen["posts"]) == 1
+    patch_body = seen["patches"][0][1]["body"]
+    comment_body = seen["posts"][0][1]["body"]
+
+    assert "Current package failures on GAP `master`." in patch_body
+    assert "atlasrep 2.1" not in patch_body
+    assert "guava 3.0" in patch_body
+
+    assert "New regression event detected on GAP `master`." in comment_body
+    assert "atlasrep 2.1" not in comment_body
+    assert "guava 3.0" in comment_body
+
+
+def test_run_updates_existing_incident_for_current_failures_without_comment():
+    module = importlib.import_module("notify_ci_regressions")
+    seen = {"patches": [], "posts": []}
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+            self.links = {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class Session:
+        def get(self, url, headers=None, params=None):
+            return Response(
+                [
+                    {
+                        "number": 7550,
+                        "title": "CI regression: packages now failing on GAP master",
+                        "labels": [{"name": "ci-regression"}],
+                    }
+                ]
+            )
+
+        def post(self, url, headers=None, json=None):
+            seen["posts"].append((url, json))
+            raise AssertionError("post should not be called")
+
+        def patch(self, url, headers=None, json=None):
+            seen["patches"].append((url, json))
+            return Response({"number": 7550})
+
+    result = module.run_notification(
+        session=Session(),
+        repo="gap-system/PackageDistro",
+        token="TOKEN",
+        which_gap="master",
+        mentions=["@user1", "@user2"],
+        test_status={
+            "workflow": "https://github.com/gap-system/PackageDistro/actions/runs/10",
+            "id": "master/2026-04-25-fedcba98",
+            "pkgs": {
+                "atlasrep": {
+                    "status": "failure",
+                    "version": "2.1",
+                    "workflow_run": "https://example.invalid/job/atlasrep",
+                },
+                "guava": {
+                    "status": "failure",
+                    "version": "3.0",
+                    "workflow_run": "https://example.invalid/job/guava",
+                },
+            },
+        },
+        report_diff={"failure_changed": 0},
+        previous_statuses={"atlasrep": "failure", "guava": "failure"},
+        report_url="https://github.com/gap-system/PackageDistro/blob/data/reports/master/report.md",
+    )
+
+    assert result == {"action": "updated", "issue_number": 7550}
+    assert len(seen["patches"]) == 1
+    assert "Current package failures on GAP `master`." in seen["patches"][0][1]["body"]
+    assert "Current failures:" in seen["patches"][0][1]["body"]
     assert "atlasrep 2.1" in seen["patches"][0][1]["body"]
+    assert "guava 3.0" in seen["patches"][0][1]["body"]
+    assert seen["posts"] == []


### PR DESCRIPTION
Keep a single live ci-regression issue in sync with current failures.
Update the issue body for ongoing failures and comment on new ones.
Recreate missing incidents and close the matching issue on green runs.

AI-assisted by Codex for design, implementation, and tests.

Co-authored-by: Codex <codex@openai.com>
