### PR TITLE
tools: Mention maintainers in update PRs

### DIFF
--- a/tools/prepare_pr.py
+++ b/tools/prepare_pr.py
@@ -54,6 +54,42 @@ def infostr_for_package(pkg_json: Dict[str, Any]) -> str:
     return s
 
 
+def maintainer_mentions(pkg_json: Dict[str, Any]) -> List[str]:
+    mentions = []
+    for person in pkg_json.get("Persons", []):
+        username = person.get("GitHubUsername")
+        if username and person.get("IsMaintainer"):
+            mentions.append(f"@{username}")
+    return mentions
+
+
+def body_for_packages(pkg_jsons: List[Dict[str, Any]]) -> str:
+    body = "".join(map(infostr_for_package, pkg_jsons))
+
+    # Add link to the source repository only once, as package groups are defined
+    # via the source repository.
+    pkg_json = pkg_jsons[0]
+    if "SourceRepository" in pkg_json:
+        url = pkg_json["SourceRepository"]["URL"]
+        body += f"""- [source repository]({url})""" + "\n"
+
+    # HACK: also add the issue tracker only once; while in theory packages in a
+    # group could have different issue trackers, this is not currently the case,
+    # ever. We'll deal with it if it ever happens.
+    if "IssueTrackerURL" in pkg_json:
+        body += f"""- [issue tracker]({pkg_json["IssueTrackerURL"]})""" + "\n"
+
+    mentions = []
+    for pkg_json in pkg_jsons:
+        for mention in maintainer_mentions(pkg_json):
+            if mention not in mentions:
+                mentions.append(mention)
+    if mentions:
+        body += "\nMaintainers: " + " ".join(mentions) + "\n"
+
+    return body
+
+
 def is_new_package(pkg_name: str) -> bool:
     fname = utils.metadata_fname(pkg_name)
     result = subprocess.run(
@@ -105,20 +141,8 @@ def main(pkg_or_group_name: str, modmap: List[str]) -> None:
     print(f"PR_FILES={','.join(files)}")
 
     # generate PR body content
-    mod_json = map(utils.metadata, modified)
-    body = "".join(map(infostr_for_package, mod_json))
-
-    # add link to the source repository; we do this only once, as package groups
-    # are defined via the source repository
-    if "SourceRepository" in pkg_json:
-        url = pkg_json["SourceRepository"]["URL"]
-        body += f"""- [source repository]({url})""" + "\n"
-
-    # HACK: also add the issue tracker only once; while in theory packages in
-    # a group could have different issue trackers, this is not currently the case,
-    # ever. We'll deal with it if it ever happens
-    if "IssueTrackerURL" in pkg_json:
-        body += f"""- [issue tracker]({pkg_json["IssueTrackerURL"]})""" + "\n"
+    mod_json = [utils.metadata(pkg_name) for pkg_name in modified]
+    body = body_for_packages(mod_json)
 
     # generate multiline environment variable using "heredoc" syntax, as per
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

--- a/tools/tests/test_prepare_pr.py
+++ b/tools/tests/test_prepare_pr.py
@@ -7,7 +7,7 @@ sys.path.insert(
     0, "/".join(os.path.dirname(os.path.realpath(__file__)).split("/")[:-1])
 )
 
-from prepare_pr import infostr_for_package
+from prepare_pr import body_for_packages, infostr_for_package
 
 
 def test_infostr_for_package_includes_archive_size():
@@ -27,3 +27,39 @@ def test_infostr_for_package_includes_archive_size():
     assert (
         "[[source archive](https://example.com/testpkg-1.0.tar.gz) (12.9 MB)]" in info
     )
+
+
+def test_body_for_packages_mentions_maintainers_with_github_usernames():
+    pkg_json = {
+        "ArchiveFormats": ".tar.gz",
+        "ArchiveSize": 12939427,
+        "ArchiveURL": "https://example.com/testpkg-1.0",
+        "IssueTrackerURL": "https://example.com/issues",
+        "PackageInfoURL": "https://example.com/PackageInfo.g",
+        "PackageName": "TestPkg",
+        "PackageWWWHome": "https://example.com",
+        "README_URL": "https://example.com/README",
+        "SourceRepository": {"URL": "https://example.com/repo"},
+        "Version": "1.0",
+        "Persons": [
+            {
+                "FirstNames": "Maint",
+                "GitHubUsername": "maintainer",
+                "IsMaintainer": True,
+            },
+            {
+                "FirstNames": "Author",
+                "GitHubUsername": "author",
+                "IsMaintainer": False,
+            },
+            {
+                "FirstNames": "No Handle",
+                "IsMaintainer": True,
+            },
+        ],
+    }
+
+    body = body_for_packages([pkg_json])
+
+    assert "Maintainers: @maintainer" in body
+    assert "@author" not in body


### PR DESCRIPTION
Add GitHub mentions for package maintainers with known handles.

AI tool: Codex assisted with code and tests.

Co-authored-by: Codex <codex@openai.com>
