### PR TITLE
tools: Name packages in CI regression titles

### DIFF
--- a/tools/notify_ci_regressions.py
+++ b/tools/notify_ci_regressions.py
@@ -71,6 +71,17 @@ def format_package_lines(rows: list[dict[str, str]]) -> str:
     )
 
 
+def render_issue_title(which_gap: str, rows: list[dict[str, str]]) -> str:
+    names = sorted(row["name"] for row in rows)
+    if len(names) == 1:
+        package_summary = f'"{names[0]}"'
+    elif len(names) == 2:
+        package_summary = f'"{names[0]}" and "{names[1]}"'
+    else:
+        package_summary = f'"{names[0]}" and {len(names) - 1} more packages'
+    return f"{ISSUE_TITLE_PREFIX} {package_summary} now failing on GAP {which_gap}"
+
+
 def render_issue_body(
     which_gap: str,
     workflow_url: str,
@@ -130,7 +141,7 @@ def find_open_incident_issue(
         "labels": ISSUE_LABEL,
         "per_page": "100",
     }
-    expected_title = f"{ISSUE_TITLE_PREFIX} packages now failing on GAP {which_gap}"
+    title_suffix = f" now failing on GAP {which_gap}"
     res = session.get(
         url,
         headers=github_headers(token),
@@ -138,7 +149,8 @@ def find_open_incident_issue(
     )
     res.raise_for_status()
     for issue in res.json():
-        if issue["title"] == expected_title:
+        title = issue["title"]
+        if title.startswith(f"{ISSUE_TITLE_PREFIX} ") and title.endswith(title_suffix):
             return issue
     return None
 
@@ -182,7 +194,7 @@ def run_notification(
         return {"action": "closed", "issue_number": issue["number"]}
 
     changed_rows = changed_failures(test_status, previous_statuses or {})
-    title = f"{ISSUE_TITLE_PREFIX} packages now failing on GAP {which_gap}"
+    title = render_issue_title(which_gap, current_rows)
     if issue is None:
         body = render_issue_body(
             which_gap,

--- a/tools/tests/test_notify_ci_regressions.py
+++ b/tools/tests/test_notify_ci_regressions.py
@@ -10,6 +10,26 @@ sys.path.insert(
 )
 
 
+def test_render_issue_title_names_current_failures():
+    module = importlib.import_module("notify_ci_regressions")
+
+    assert (
+        module.render_issue_title("master", [{"name": "atlasrep"}])
+        == 'CI regression: "atlasrep" now failing on GAP master'
+    )
+    assert (
+        module.render_issue_title("master", [{"name": "atlasrep"}, {"name": "guava"}])
+        == 'CI regression: "atlasrep" and "guava" now failing on GAP master'
+    )
+    assert (
+        module.render_issue_title(
+            "master",
+            [{"name": "atlasrep"}, {"name": "guava"}, {"name": "io"}],
+        )
+        == 'CI regression: "atlasrep" and 2 more packages now failing on GAP master'
+    )
+
+
 def test_run_returns_without_api_calls_when_no_failures_and_no_issue():
     module = importlib.import_module("notify_ci_regressions")
     calls = []
@@ -271,7 +291,7 @@ def test_run_creates_incident_issue_with_mentions_for_first_regression():
     assert "@user1 @user2" in body
     assert "atlasrep 2.1" in body
     assert (
-        "CI regression: packages now failing on GAP master"
+        'CI regression: "atlasrep" now failing on GAP master'
         == seen["posts"][0][1]["title"]
     )
 
@@ -422,6 +442,10 @@ def test_run_updates_existing_incident_and_comments_without_mentions():
     assert "Current failures:" in patch_body
     assert "atlasrep 2.1" in patch_body
     assert "guava 3.0" in patch_body
+    assert (
+        seen["patches"][0][1]["title"]
+        == 'CI regression: "atlasrep" and "guava" now failing on GAP master'
+    )
 
     assert "New regression event detected on GAP `master`." in comment_body
     assert "New failures:" in comment_body
@@ -455,7 +479,9 @@ def test_run_updates_existing_incident_and_comments_for_mixed_delta():
                 [
                     {
                         "number": 7550,
-                        "title": "CI regression: packages now failing on GAP master",
+                        "title": (
+                            'CI regression: "atlasrep" now failing on GAP master'
+                        ),
                         "labels": [{"name": "ci-regression"}],
                     }
                 ]
@@ -501,6 +527,10 @@ def test_run_updates_existing_incident_and_comments_for_mixed_delta():
     assert len(seen["posts"]) == 1
     patch_body = seen["patches"][0][1]["body"]
     comment_body = seen["posts"][0][1]["body"]
+    assert (
+        seen["patches"][0][1]["title"]
+        == 'CI regression: "guava" now failing on GAP master'
+    )
 
     assert "Current package failures on GAP `master`." in patch_body
     assert "atlasrep 2.1" not in patch_body


### PR DESCRIPTION
Name the current failing package set in CI regression issue titles.

Co-authored-by: Codex <codex@openai.com>
