### PR TITLE
tools: Gather system deps from metadata

### DIFF
--- a/tools/gather_dependencies.py
+++ b/tools/gather_dependencies.py
@@ -15,37 +15,30 @@ This script installs Ubuntu packages required by the GAP packages specified
 on the command line.
 """
 
-import os
 import sys
-from typing import List, Set
+from typing import Any, Dict, List, Set
 
 from utils import metadata, normalize_pkg_name
 
 # The following maps names of GAP packages to lists of Ubuntu package names.
 # The Ubuntu packages should be installed in order to build and/or use the GAP
-# package
+# package. It serves as a fallback for those packages which do not yet set
+# NeededSystemPackages in their package metadata.
+#
+# This map should be removed once it becomes empty.
 ubtunu_deps = {
-    "4ti2interface": ["4ti2"],
-    "alnuth": ["pari-gp"],
     "browse": ["libncurses5-dev"],
-    "cddinterface": ["libcdd-dev"],
-    "curlinterface": ["libcurl4-openssl-dev"],
-    "float": ["libmpc-dev", "libmpfi-dev", "libmpfr-dev"],
-    "gapdoc": [
-        "texlive-latex-base",
-        "texlive-latex-recommended",
-        "texlive-latex-extra",
-        "texlive-fonts-recommended",
-    ],
     "hap": ["graphviz", "imagemagick"],
-    "localizeringforhomalg": ["singular"],
-    "normalizinterface": ["libnormaliz-dev"],
-    "polymaking": ["polymake"],
-    "ringsforhomalg": ["singular"],
-    "singular": ["singular"],
-    "typeset": ["graphviz", "texlive", "preview-latex-style", "dot2tex"],
-    "zeromqinterface": ["libzmq3-dev"],
 }
+
+
+def metadata_ubuntu_packages(pkg_json: Dict[str, Any]) -> Set[str]:
+    system_packages = pkg_json["Dependencies"].get("NeededSystemPackages", {})
+    return set(package_names[0] for package_names in system_packages.get("Ubuntu", []))
+
+
+def ubuntu_packages(pkg_name: str, pkg_json: Dict[str, Any]) -> Set[str]:
+    return set(ubtunu_deps.get(pkg_name, [])) | metadata_ubuntu_packages(pkg_json)
 
 
 def gather_dependencies(pkg_name: str, seen: set) -> set:
@@ -54,7 +47,7 @@ def gather_dependencies(pkg_name: str, seen: set) -> set:
     except:
         return set()
     seen.add(pkg_name)
-    deps = set(ubtunu_deps.get(pkg_name, []))
+    deps = ubuntu_packages(pkg_name, pkg_json)
 
     tmp = pkg_json["Dependencies"]
     gap_deps = tmp["NeededOtherPackages"]

--- a/tools/tests/test_gather_dependencies.py
+++ b/tools/tests/test_gather_dependencies.py
@@ -1,0 +1,66 @@
+# pylint: disable=missing-function-docstring
+
+import os
+import sys
+
+sys.path.insert(
+    0, "/".join(os.path.dirname(os.path.realpath(__file__)).split("/")[:-1])
+)
+
+import gather_dependencies
+
+
+def test_metadata_ubuntu_packages_extracts_ubuntu_entries():
+    assert gather_dependencies.metadata_ubuntu_packages(
+        {
+            "Dependencies": {
+                "NeededSystemPackages": {
+                    "Homebrew": [["ignored"]],
+                    "Ubuntu": [["dynamic-dev"], ["dynamic-runtime"]],
+                }
+            }
+        }
+    ) == {"dynamic-dev", "dynamic-runtime"}
+
+
+def test_metadata_ubuntu_packages_handles_missing_field():
+    assert gather_dependencies.metadata_ubuntu_packages({"Dependencies": {}}) == set()
+
+
+def test_gather_dependencies_uses_needed_system_packages(monkeypatch):
+    metadata = {
+        "root": {
+            "Dependencies": {
+                "NeededOtherPackages": [],
+                "NeededSystemPackages": {
+                    "Ubuntu": [["dynamic-dev"], ["dynamic-runtime"]]
+                },
+                "SuggestedOtherPackages": [],
+            }
+        }
+    }
+
+    monkeypatch.setattr(gather_dependencies, "metadata", metadata.__getitem__)
+    monkeypatch.setattr(gather_dependencies, "ubtunu_deps", {"root": ["legacy-dev"]})
+
+    assert gather_dependencies.gather_dependencies("root", set()) == {
+        "dynamic-dev",
+        "dynamic-runtime",
+        "legacy-dev",
+    }
+
+
+def test_gather_dependencies_falls_back_to_legacy_table(monkeypatch):
+    metadata = {
+        "root": {
+            "Dependencies": {
+                "NeededOtherPackages": [],
+                "SuggestedOtherPackages": [],
+            }
+        }
+    }
+
+    monkeypatch.setattr(gather_dependencies, "metadata", metadata.__getitem__)
+    monkeypatch.setattr(gather_dependencies, "ubtunu_deps", {"root": ["legacy-dev"]})
+
+    assert gather_dependencies.gather_dependencies("root", set()) == {"legacy-dev"}


### PR DESCRIPTION
Read Ubuntu package dependencies from NeededSystemPackages in
package metadata while retaining the legacy table as fallback
coverage.

AI disclosure: OpenAI Codex helped implement and test this change.

Co-authored-by: Codex <codex@openai.com>