### PR TITLE
Only run `apt-get update` if we plan to install something

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -167,9 +167,9 @@ jobs:
       # TOOD: dependencies should come from a container
       - name: "Install binary package dependencies"
         run: |
-          sudo apt-get update
           deps=$(tools/gather_dependencies.py packages/*/meta.json)
           if [[ -n "$deps" ]]; then
+            sudo apt-get update
             echo "Installing required binary depedencies: $deps"
             sudo apt-get install --no-install-recommends $deps
           else
@@ -364,9 +364,9 @@ jobs:
 
       - name: "Install binary package dependencies"
         run: |
-          sudo apt-get update
           deps=$(tools/gather_dependencies.py ${{ matrix.package }})
           if [[ -n "$deps" ]]; then
+            sudo apt-get update
             echo "Installing required binary depedencies: $deps"
             sudo apt-get install --no-install-recommends $deps
           else


### PR DESCRIPTION
The idea is to not update the apt caches when we don't need to. Should have little impact, but I hope this might prevent the occasional workflow failure due to this command hanging (e.g. [here](https://github.com/gap-system/PackageDistro/actions/runs/26536997591/job/78170269938#step:8:46)).

I'm not 100% sure this is safe, as a future `apt-get install` command not preceded by `apt update` might be negatively affected... but I didn't notice any such commands.