### PR TITLE
Add `libnormaliz-dev` dependency fallback for `NormalizInterface`

### DIFF
--- a/tools/gather_dependencies.py
+++ b/tools/gather_dependencies.py
@@ -29,6 +29,7 @@ from utils import metadata, normalize_pkg_name
 ubtunu_deps = {
     "browse": ["libncurses5-dev"],
     "hap": ["graphviz", "imagemagick"],
+    "normalizinterface": ["libnormaliz-dev"],
 }
 
 


### PR DESCRIPTION
Should resolve #1401 for now, although this of course means we don't test `NormalizInterface` with the bundled `normaliz`...