### PR TITLE
tools: Harden package archive downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ For example, the SHA256 in this excerpt of a `meta.json` file refers to the
     "ArchiveSHA256": "15c516d89863916ef8f4b0d5c68f5b79cb41b75741fc3b604a6a868569dcda38",
     "ArchiveURL": "https://github.com/homalg-project/ToricVarieties_project/releases/download/2022-03-04/ToricVarieties",
 
+Note that `ArchiveFormats` is not necessarily in the same order as in the
+package's `PackageInfo.g`: when importing a package we move `.tar.gz` to the
+front if the package offers it.
+
 
 ### GitHub Workflows
 

--- a/packages/browse/meta.json
+++ b/packages/browse/meta.json
@@ -1,8 +1,8 @@
 {
   "AbstractHTML": "The <span class='pkgname'>Browse</span> package provides three levels of functionality</p><ul><li>A <span class='pkgname'>GAP</span> interface to the C-library <a href='http://www.gnu.org/software/ncurses/ncurses.html'>ncurses</a>.</li><li>A generic function for interactive browsing through two-dimensional arrays of data.</li><li>Several applications of the first two, e.g., a method for browsing character tables, browsing through the content of some data collections, or some games.</li></ul><p>",
-  "ArchiveFormats": ".tar.bz2 .tar.gz -win.zip",
-  "ArchiveSHA256": "a367fc74cbcfe9bedc626fff79ce6c5c3ea404c04414f80746cb3ab36acfbb71",
-  "ArchiveSize": 1494440,
+  "ArchiveFormats": ".tar.gz .tar.bz2 -win.zip",
+  "ArchiveSHA256": "90f2e8f71aa4b9276a80370fc2503daeba9d3555e159a968559731da18be6b60",
+  "ArchiveSize": 1856409,
   "ArchiveURL": "https://www.math.rwth-aachen.de/~Browse/Browse-1.8.23",
   "AvailabilityTest": null,
   "Date": "2026-07-30",

--- a/packages/edim/meta.json
+++ b/packages/edim/meta.json
@@ -1,8 +1,9 @@
 {
   "AbstractHTML": "This package provides  a collection of functions for computing the Smith normal form of integer matrices and some related utilities.",
   "AcceptDate": "08/1999",
-  "ArchiveFormats": ".tar.bz2  .tar.gz   -win.zip",
-  "ArchiveSHA256": "b59bb607bc9831b8224410946c33b12b82b252c662803835197821c2fb18f9e2",
+  "ArchiveFormats": ".tar.gz .tar.bz2 -win.zip",
+  "ArchiveSHA256": "32ebc14df670205aa08a4f1cdf22ae59e5665009e0b34ec4f5efe422c83b6a42",
+  "ArchiveSize": 367765,
   "ArchiveURL": "https://www.math.rwth-aachen.de/~Frank.Luebeck/EDIM/EDIM-1.3.8",
   "Autoload": false,
   "AvailabilityTest": null,

--- a/packages/gapdoc/meta.json
+++ b/packages/gapdoc/meta.json
@@ -1,9 +1,9 @@
 {
   "AbstractHTML": "This package contains a definition of a structure for <span class='pkgname'>GAP</span> (package) documentation, based on XML. It also contains  conversion programs for producing text-, PDF- or HTML-versions of such documents, with hyperlinks if possible.",
   "AcceptDate": "10/2006",
-  "ArchiveFormats": ".tar.bz2 .tar.gz -win.zip",
-  "ArchiveSHA256": "eb760738ca43a2dc5d0a891f0308303e51943745157cc27b3dd8da9a45004681",
-  "ArchiveSize": 1557710,
+  "ArchiveFormats": ".tar.gz .tar.bz2 -win.zip",
+  "ArchiveSHA256": "058c83fee15ea99852cfe8171b468342008a10f5532c414d70ab18b246a02dee",
+  "ArchiveSize": 1750931,
   "ArchiveURL": "https://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/GAPDoc-1.6.10",
   "AvailabilityTest": null,
   "CommunicatedBy": "Steve Linton (St Andrews)",

--- a/tools/download_packages.py
+++ b/tools/download_packages.py
@@ -22,65 +22,115 @@ https://github.com/gap-system/PackageDistro
 The packages to download should be given as command line arguments, each
 given name must either correspond to a subdirectory in the cwd named
 `pkg_name` and containing a `meta.json` file, or be of the form
-`pkg_name/meta.json`.
+`pkg_name/meta.json`. If no packages are given, all packages are downloaded.
 
-If the archive already exists in the `_archives` directory, then it is not
-downloaded again.
+If the archive already exists in the `_archives` directory and matches the
+expected checksum, then it is not downloaded again.
+
+Downloading an archive that fails to verify does not abort the run; the
+remaining packages are still attempted, and a summary of the failures is
+printed at the end.
 
 Usage:
 
     > tools/download_packages.py digraphs walrus/meta.json
-    digraphs: _archives/digraphs-1.5.0.tar.gz already exists, not downloading again
-    walrus: _archives/walrus-0.9991.tar.gz already exists, not downloading again
+    _archives/digraphs-1.5.0.tar.gz already exists, not downloading again
+    _archives/walrus-0.9991.tar.gz already exists, not downloading again
 
 """
 
+import argparse
 import os
 import sys
 from os.path import join
 from typing import List
 
+import requests
 from utils import (
+    all_packages,
     archive_name,
     archive_url,
     download,
-    error,
     metadata,
     normalize_pkg_name,
     notice,
     sha256,
+    warning,
 )
+
+
+class ChecksumError(Exception):
+    """Raised when a downloaded archive does not have the expected checksum."""
 
 
 def download_archive(archive_dir: str, pkg_name: str) -> str:
     """Returns the full archive name (including archive_dir) for the downloaded
     archive of the package `pkg_name`"""
-    if not os.path.exists(archive_dir):
-        os.mkdir(archive_dir)
+    os.makedirs(archive_dir, exist_ok=True)
 
     pkg_json = metadata(pkg_name)
+    expected_sha = pkg_json.get("ArchiveSHA256")
     archive_fname = join(archive_dir, archive_name(pkg_name))
 
-    if os.path.exists(archive_fname) and os.path.isfile(archive_fname):
+    if os.path.isfile(archive_fname):
         archive_sha = sha256(archive_fname)
-        if "ArchiveSHA256" in pkg_json and pkg_json["ArchiveSHA256"] != archive_sha:
-            notice(
-                f'{archive_fname} has SHA256 {archive_sha}, expected {pkg_json["ArchiveSHA256"]}'
-            )
-            os.remove(archive_fname)
-        else:
+        if expected_sha is None or expected_sha == archive_sha:
             print(f"{archive_fname} already exists, not downloading again")
             return archive_fname
+        notice(f"{archive_fname} has SHA256 {archive_sha}, expected {expected_sha}")
+
     url = archive_url(pkg_json)
     notice(f"downloading {url} to {archive_fname}")
-    download(url, archive_fname)
+
+    # Download to a temporary file next to the target, and only move it into
+    # place once it has been verified. The archive directory may be served
+    # directly by a web server (as it is on files.gap-system.org), where a
+    # partially downloaded archive must never become visible. This also keeps
+    # an existing, good archive intact if the download fails.
+    tmp_fname = archive_fname + ".part"
+    try:
+        download(url, tmp_fname)
+        if expected_sha is not None:
+            actual_sha = sha256(tmp_fname)
+            if actual_sha != expected_sha:
+                raise ChecksumError(
+                    f"{url} has SHA256 {actual_sha}, expected {expected_sha}"
+                )
+        os.replace(tmp_fname, archive_fname)
+    except BaseException:
+        if os.path.exists(tmp_fname):
+            os.remove(tmp_fname)
+        raise
     return archive_fname
 
 
-def main(pkg_names: List[str]) -> None:
-    archive_dir = "_archives"
+def main(argv: List[str]) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "packages",
+        nargs="*",
+        help="packages to download (default: all packages)",
+    )
+    parser.add_argument(
+        "--archive-dir",
+        default="_archives",
+        help="directory to download the archives into (default: _archives)",
+    )
+    args = parser.parse_args(argv)
+
+    pkg_names = [normalize_pkg_name(p) for p in args.packages] or all_packages()
+
+    failures: List[str] = []
     for pkg_name in pkg_names:
-        download_archive(archive_dir, normalize_pkg_name(pkg_name))
+        try:
+            download_archive(args.archive_dir, pkg_name)
+        except (requests.RequestException, ChecksumError, OSError) as e:
+            warning(f"{pkg_name}: {e}")
+            failures.append(pkg_name)
+
+    if failures:
+        warning(f"failed to download {len(failures)} archive(s): {' '.join(failures)}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/scan_for_updates.py
+++ b/tools/scan_for_updates.py
@@ -109,6 +109,12 @@ def import_packages(pkginfo_paths: List[str]) -> None:
     pkginfos = parse_pkginfo_files(pkginfo_paths)
     for pkg_json in pkginfos:
         pkgname = pkg_json["PackageName"].lower()
+        # Do this before anything else reads the format: the archive we
+        # download, and hence the checksum and size we record, must be the one
+        # our consumers will use.
+        pkg_json["ArchiveFormats"] = utils.sort_archive_formats(
+            pkg_json["ArchiveFormats"]
+        )
         url = archive_url(pkg_json)
         archive_fname = join(archive_dir, url.split("/")[-1])
         try:

--- a/tools/tests/packages/badsha/meta.json
+++ b/tools/tests/packages/badsha/meta.json
@@ -1,0 +1,7 @@
+{
+  "ArchiveFormats": ".tar.gz",
+  "ArchiveSHA256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "ArchiveURL": "https://example.com/badsha/badsha-1.0",
+  "PackageName": "badsha",
+  "Version": "1.0"
+}

--- a/tools/tests/packages/goodsha/meta.json
+++ b/tools/tests/packages/goodsha/meta.json
@@ -1,0 +1,7 @@
+{
+  "ArchiveFormats": ".tar.gz",
+  "ArchiveSHA256": "45ec324678494670098df213a3b5dbcf8a8fec20bd8c53389ba1f9c4f72b2383",
+  "ArchiveURL": "https://example.com/goodsha/goodsha-1.0",
+  "PackageName": "goodsha",
+  "Version": "1.0"
+}

--- a/tools/tests/test_download_packages.py
+++ b/tools/tests/test_download_packages.py
@@ -14,6 +14,7 @@ from os.path import exists, join
 
 import mock
 import pytest
+import requests
 from requests import RequestException
 
 sys.path.insert(
@@ -21,10 +22,10 @@ sys.path.insert(
 )
 
 
-from download_packages import download_archive, main
+from download_packages import ChecksumError, download_archive, main
 
 # TODO: move the tests for these functions to their own test file?
-from utils import archive_name, archive_url, metadata
+from utils import _should_retry, archive_name, archive_url, download, metadata
 
 
 @pytest.fixture
@@ -119,3 +120,108 @@ def test_download_archive(ensure_in_tests_dir, tmpdir):
 def test_main(ensure_in_tests_dir):
     main(["unipot", "aclib"])
     shutil.rmtree("_archives")
+
+
+# The "goodsha" and "badsha" test packages exist so that the checksum handling
+# can be exercised without network access: `fake_download` always writes
+# FAKE_ARCHIVE, which matches the checksum recorded for "goodsha" but not the
+# one recorded for "badsha".
+FAKE_ARCHIVE = b"test archive contents\n"
+
+
+def fake_download(url, dst):
+    with open(dst, "wb") as f:
+        f.write(FAKE_ARCHIVE)
+
+
+def test_download_archive_verifies_checksum(ensure_in_tests_dir, tmpdir):
+    with mock.patch("download_packages.download", side_effect=fake_download):
+        fname = download_archive(str(tmpdir), "goodsha")
+    assert exists(fname)
+    assert not exists(fname + ".part")
+    with open(fname, "rb") as f:
+        assert f.read() == FAKE_ARCHIVE
+
+
+def test_download_archive_bad_checksum(ensure_in_tests_dir, tmpdir):
+    archive_fname = join(str(tmpdir), archive_name("badsha"))
+
+    # A pre-existing, good archive must survive a failed re-download.
+    with open(archive_fname, "wb") as f:
+        f.write(b"previous contents")
+
+    with mock.patch("download_packages.download", side_effect=fake_download):
+        with pytest.raises(ChecksumError):
+            download_archive(str(tmpdir), "badsha")
+
+    # No partial download is left behind, and the old archive is untouched.
+    assert not exists(archive_fname + ".part")
+    with open(archive_fname, "rb") as f:
+        assert f.read() == b"previous contents"
+
+
+def test_download_archive_removes_part_file_on_error(ensure_in_tests_dir, tmpdir):
+    with mock.patch(
+        "download_packages.download", side_effect=RequestException("Failed Request")
+    ):
+        with pytest.raises(RequestException):
+            download_archive(str(tmpdir), "goodsha")
+    assert not exists(join(str(tmpdir), archive_name("goodsha") + ".part"))
+    assert not exists(join(str(tmpdir), archive_name("goodsha")))
+
+
+def http_error(status_code):
+    response = mock.Mock()
+    response.status_code = status_code
+    return requests.HTTPError(response=response)
+
+
+def ok_response(content=FAKE_ARCHIVE):
+    response = mock.Mock()
+    response.raise_for_status.return_value = None
+    response.raw.stream.return_value = iter([content])
+    return response
+
+
+def test_should_retry():
+    # Transient: worth another attempt.
+    assert _should_retry(requests.ConnectionError())
+    assert _should_retry(requests.Timeout())
+    assert _should_retry(http_error(429))
+    assert _should_retry(http_error(503))
+
+    # Permanent: retrying would only waste time.
+    assert not _should_retry(http_error(404))
+    assert not _should_retry(http_error(401))
+    assert not _should_retry(RequestException("Failed Request"))
+
+
+def test_download_retries_transient_failures(tmpdir):
+    dst = join(str(tmpdir), "archive.tar.gz")
+    responses = [requests.ConnectionError(), http_error(503), ok_response()]
+    with mock.patch("time.sleep"):  # do not actually wait between attempts
+        with mock.patch("requests.get", side_effect=responses) as get:
+            download("https://example.com/archive.tar.gz", dst)
+    assert get.call_count == 3
+    with open(dst, "rb") as f:
+        assert f.read() == FAKE_ARCHIVE
+
+
+def test_download_does_not_retry_permanent_failures(tmpdir):
+    dst = join(str(tmpdir), "archive.tar.gz")
+    with mock.patch("time.sleep"):
+        with mock.patch("requests.get", side_effect=http_error(404)) as get:
+            with pytest.raises(requests.HTTPError):
+                download("https://example.com/archive.tar.gz", dst)
+    assert get.call_count == 1
+
+
+def test_main_continues_after_failure(ensure_in_tests_dir, tmpdir):
+    # A failing package must not stop the ones listed after it.
+    with mock.patch("download_packages.download", side_effect=fake_download):
+        with pytest.raises(SystemExit) as e:
+            main(["badsha", "goodsha", "--archive-dir", str(tmpdir)])
+    assert e.value.code == 1
+
+    assert not exists(join(str(tmpdir), archive_name("badsha")))
+    assert exists(join(str(tmpdir), archive_name("goodsha")))

--- a/tools/tests/test_download_packages.py
+++ b/tools/tests/test_download_packages.py
@@ -6,6 +6,8 @@
 This module contains some tests for the download_packages.py script
 """
 
+import glob
+import json
 import os
 import runpy
 import shutil
@@ -25,7 +27,14 @@ sys.path.insert(
 from download_packages import ChecksumError, download_archive, main
 
 # TODO: move the tests for these functions to their own test file?
-from utils import _should_retry, archive_name, archive_url, download, metadata
+from utils import (
+    _should_retry,
+    archive_name,
+    archive_url,
+    download,
+    metadata,
+    sort_archive_formats,
+)
 
 
 @pytest.fixture
@@ -73,6 +82,38 @@ def test_archive_name(ensure_in_tests_dir):
         meta = archive_name("badjson")
     assert e.type == SystemExit
     assert e.value.code == 1
+
+
+def test_sort_archive_formats():
+    # A preferred format is moved to the front, others keep their order.
+    assert (
+        sort_archive_formats(".tar.bz2 .tar.gz -win.zip") == ".tar.gz .tar.bz2 -win.zip"
+    )
+    assert sort_archive_formats(".tar.gz .zip") == ".tar.gz .zip"
+    assert sort_archive_formats(".zip .tar.bz2") == ".zip .tar.bz2"
+
+    # Nothing to prefer, and nothing to do.
+    assert sort_archive_formats(".tar.bz2") == ".tar.bz2"
+    assert sort_archive_formats(".tar.gz") == ".tar.gz"
+
+    # Some PackageInfo.g files separate the formats by more than one space.
+    assert (
+        sort_archive_formats(".tar.bz2  .tar.gz   -win.zip")
+        == ".tar.gz .tar.bz2 -win.zip"
+    )
+
+
+def test_distributed_metadata_prefers_tar_gz():
+    # Guard against a package sneaking back in that offers .tar.gz but does not
+    # list it first: the first format is the one we download and mirror, and
+    # some consumers cannot unpack .tar.bz2.
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+    metas = sorted(glob.glob(join(root, "packages", "*", "meta.json")))
+    assert metas, "found no packages to check"
+    for fname in metas:
+        with open(fname, "r", encoding="utf-8") as f:
+            formats = json.load(f)["ArchiveFormats"]
+        assert formats == sort_archive_formats(formats), fname
 
 
 def test_archive_url():

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -13,10 +13,24 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 from os.path import join
 from typing import Any, Dict, List, NoReturn, Tuple
 
 import requests
+
+# Timeouts in seconds, as (connect, read). Without these, a stalled connection
+# blocks forever, which matters for unattended runs (e.g. the mirror on
+# files.gap-system.org). Both are deliberately generous: the point is to bound
+# a hang, not to enforce a fast connection. Poor networks have been observed
+# taking over 20 seconds just to connect to the host serving GitHub release
+# assets, and the read timeout applies between reads, not to the whole
+# download, so a large archive on a slow link is fine.
+DOWNLOAD_TIMEOUT = (30, 60)
+
+# How many times to attempt a download before giving up. Only transient
+# failures are retried; see `_should_retry`.
+DOWNLOAD_ATTEMPTS = 3
 
 
 # print notices in green
@@ -48,19 +62,45 @@ def sha256(fname: str) -> str:
     return hash_archive.hexdigest()
 
 
+def _should_retry(e: requests.RequestException) -> bool:
+    """Return whether the failed request `e` is worth retrying.
+
+    Connection problems and timeouts are transient. So are HTTP 429 (rate
+    limited) and 5xx responses. Anything else -- notably a 404 -- will fail the
+    same way again, so retrying only wastes time.
+    """
+    if isinstance(e, requests.HTTPError) and e.response is not None:
+        return e.response.status_code == 429 or e.response.status_code >= 500
+    return isinstance(e, (requests.ConnectionError, requests.Timeout))
+
+
 def download(url: str, dst: str) -> None:
-    """Download the file at the given URL `url` to the file with path `dst`."""
-    response = requests.get(url, stream=True)
-    response.raise_for_status()  # raise a meaningful (?) exception if there was e.g. a 404 error
-    os.makedirs(os.path.dirname(dst), exist_ok=True)
-    with open(dst, "wb") as f:
-        for chunk in response.raw.stream(16384, decode_content=True):
-            if chunk:
-                f.write(chunk)
+    """Download the file at the given URL `url` to the file with path `dst`.
+
+    Transient failures are retried; if every attempt fails, the underlying
+    `requests.RequestException` is raised.
+    """
+    dst_dir = os.path.dirname(dst)
+    if dst_dir:
+        os.makedirs(dst_dir, exist_ok=True)
+    for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
+        try:
+            response = requests.get(url, stream=True, timeout=DOWNLOAD_TIMEOUT)
+            response.raise_for_status()  # raise a meaningful (?) exception if there was e.g. a 404 error
+            with open(dst, "wb") as f:
+                for chunk in response.raw.stream(16384, decode_content=True):
+                    if chunk:
+                        f.write(chunk)
+            return
+        except requests.RequestException as e:
+            if attempt == DOWNLOAD_ATTEMPTS or not _should_retry(e):
+                raise
+            warning(f"downloading {url} failed ({e}), retrying")
+            time.sleep(2**attempt)
 
 
 def download_to_memory(url: str) -> bytes:
-    response = requests.get(url)
+    response = requests.get(url, timeout=DOWNLOAD_TIMEOUT)
     response.raise_for_status()
     return response.content
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -133,15 +133,38 @@ def metadata(pkg_name: str) -> Dict[str, Any]:
     return pkg_json
 
 
+# Archive formats to put first, in order of preference. Our own tooling uses
+# the first format listed in `ArchiveFormats`: it is the archive we download,
+# checksum, redistribute and mirror to files.gap-system.org, and hence the only
+# one guaranteed to be available from there. Prefer .tar.gz as the most widely
+# supported -- some consumers cannot unpack .tar.bz2 at all.
+PREFERRED_ARCHIVE_FORMATS = [".tar.gz"]
+
+
+def sort_archive_formats(formats: str) -> str:
+    """Reorder a space separated `ArchiveFormats` value, preferred formats first.
+
+    Formats we have no opinion about keep their original relative order.
+    """
+    rank = {fmt: i for i, fmt in enumerate(PREFERRED_ARCHIVE_FORMATS)}
+    unranked = len(PREFERRED_ARCHIVE_FORMATS)
+    return " ".join(sorted(formats.split(), key=lambda f: rank.get(f, unranked)))
+
+
+def archive_format(pkg_json: Dict[str, Any]) -> str:
+    """The archive format the distribution uses for this package."""
+    # Note that `split()` without arguments also copes with the handful of
+    # PackageInfo.g files that separate the formats by more than one space.
+    return pkg_json["ArchiveFormats"].split()[0]
+
+
 def archive_name(pkg_name: str) -> str:
     pkg_json = metadata(pkg_name)
-    return (
-        pkg_json["ArchiveURL"].split("/")[-1] + pkg_json["ArchiveFormats"].split(" ")[0]
-    )
+    return pkg_json["ArchiveURL"].split("/")[-1] + archive_format(pkg_json)
 
 
 def archive_url(pkg_json: Dict[str, Any]) -> str:
-    return pkg_json["ArchiveURL"] + pkg_json["ArchiveFormats"].split(" ")[0]
+    return pkg_json["ArchiveURL"] + archive_format(pkg_json)
 
 
 # https://stackoverflow.com/questions/8299386/modifying-a-symlink-in-python/55742015#55742015


### PR DESCRIPTION
Makes `tools/download_packages.py` suitable for unattended use. This is a
prerequisite for mirroring the package archives to files.gap-system.org,
which is now driven by a timer on that host (see
https://github.com/gap-system/gap-files), but the changes are equally
relevant to CI.

A single failing package no longer aborts the whole run: failures are
collected and reported at the end, and the remaining packages are still
attempted. Previously the first network error meant every package listed
after it was silently never tried. Requests now have a timeout and are
retried on transient failures — connection errors, timeouts, HTTP 429 and
5xx — while a 404 still fails immediately rather than being retried three
times.

Archives are downloaded to a temporary file and only moved into place once
their checksum has been verified. Previously only pre-existing files were
ever checked, so a corrupt or truncated download was not noticed until the
next run. On the mirror the archive directory is served directly over HTTP,
where a partially downloaded file must never become visible.

Note that `assemble_distro.py` does not catch these errors, so a checksum
mismatch now aborts assembling the distribution rather than silently
packaging a corrupt archive.

The new tests are self-contained and do not need network access.

AI disclosure: prepared with Claude Code, which drafted the code, tests and
this description; reviewed by the pull request author.