### PR TITLE
tools: Fix the scan_for_updates tests

### DIFF
--- a/tools/tests/test_scan_for_updates.py
+++ b/tools/tests/test_scan_for_updates.py
@@ -86,30 +86,35 @@ def test_scan_for_one_update(ensure_in_tests_dir, tmpdir):
 def test_scan_updates(ensure_in_tests_dir, tmpdir):
     if shutil.which("gap") == None:
         return
-    with pytest.raises(SystemExit) as e:
-        scan_for_updates(str(tmpdir), True)
-    # fails because badjson is considered and bad!
-    assert e.type == SystemExit
-    assert e.value.code == 1
-    reset()
+    try:
+        with pytest.raises(SystemExit) as e:
+            # fails because badjson is considered and bad!
+            scan_for_updates(["aclib", "badjson"], str(tmpdir), True)
+        assert e.type == SystemExit
+        assert e.value.code == 1
+    finally:
+        reset()
 
 
 def test_main(ensure_in_tests_dir):
     if shutil.which("gap") == None:
         return
-    shutil.rmtree("packages/badjson")
+    # a leftover _pkginfos directory must not upset the scan
     os.mkdir("_pkginfos")
     os.system("touch _pkginfos/.fakefile")
-    main()
-    reset()
+    try:
+        main(["aclib"])
+    finally:
+        reset()
 
 
 def test_main_again(ensure_in_tests_dir):
     if shutil.which("gap") == None:
         return
-    shutil.rmtree("packages/badjson")
-    main()
-    reset()
+    try:
+        main(["aclib"])
+    finally:
+        reset()
 
 
 def test_import_packages_records_archive_size(ensure_in_tests_dir, tmpdir):


### PR DESCRIPTION
Three tests in `tools/tests/test_scan_for_updates.py` have been failing on `main` for a while. All three come from the tests still calling functions the way they looked before their signatures changed.

**`test_scan_updates`** called

```python
scan_for_updates(str(tmpdir), True)
```

but the signature is `scan_for_updates(pkg_names, pkginfos_dir=..., disable_threads=False)`. So the temporary directory was passed as the list of package names, and `True` as the directory. `os.path.exists(True)` then inspected file descriptor 1 — which is where the `RuntimeWarning: bool is used as a file descriptor` in the test output came from — found it "exists", skipped creating the directory, and failed on the following `assert os.path.isdir(pkginfos_dir)`.

**`test_main`** called `main()`, but `main` takes a list of package names, so it raised `TypeError`.

**`test_main_again`** failed as a consequence of that: `test_main` deletes `packages/badjson` and only restores it at the end, so when it died on the `TypeError` the directory stayed deleted and the next test could not delete it again.

That last point had a nastier side effect than the failure itself: running the test suite left `packages/badjson/meta.json` deleted in the working copy, where it looks like an unrelated local change. Both `main()` tests only removed `badjson` to keep it out of `all_packages()`, so passing the packages to scan explicitly avoids touching the working copy at all, and the remaining state is restored in a `finally` block so a failure cannot leak.

With this, the full suite passes — 52 tests, up from 49 passed and 3 failed — the two file-descriptor warnings are gone, and running it twice in a row leaves the working copy clean.

Unrelated, but noticed while here: `test_assemble_distro.py` emits a `DeprecationWarning` because Python 3.14 will change the default `tarfile` extraction filter. That is a real forward-compatibility issue in `assemble_distro.py`, worth a separate fix.

AI disclosure: prepared with Claude Code, which diagnosed the failures, wrote the fix and this description; reviewed by the pull request author.
