### PR TITLE
tools: Extract tar archives with an explicit filter

### DIFF
--- a/tools/assemble_distro.py
+++ b/tools/assemble_distro.py
@@ -14,7 +14,6 @@ import gzip
 import io
 import json
 import os
-import shutil
 import subprocess
 import sys
 import typing
@@ -22,7 +21,14 @@ from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Optional
 
 from download_packages import download_archive
-from utils import all_packages, error, metadata, normalize_pkg_name, sha256
+from utils import (
+    all_packages,
+    error,
+    metadata,
+    normalize_pkg_name,
+    sha256,
+    unpack_archive,
+)
 
 
 def write_sha256(filename: str) -> None:
@@ -69,7 +75,7 @@ def make_packages_tar_gz(
             # Unpack into packagename-unpack
             unpack = os.path.join(tempdir, pkg_name + "-unpack")
             os.mkdir(unpack)
-            shutil.unpack_archive(pkg_archive, unpack)
+            unpack_archive(pkg_archive, unpack)
             # Check there is only one directory. Rename it to standardised name (pkg_name)
             pkgdirs = os.listdir(unpack)
             if len(pkgdirs) == 0:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -10,8 +10,10 @@
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 from os.path import join
@@ -97,6 +99,24 @@ def download(url: str, dst: str) -> None:
                 raise
             warning(f"downloading {url} failed ({e}), retrying")
             time.sleep(2**attempt)
+
+
+def unpack_archive(archive: str, dst: str) -> None:
+    """Unpack the archive `archive` into the directory `dst`.
+
+    Tar archives are extracted using the "data" extraction filter, which
+    refuses entries that would write outside `dst`. Python 3.14 applies that
+    filter by default and warns about relying on the old, unfiltered behaviour;
+    naming it here keeps extraction identical across Python versions.
+
+    Extraction filters are a tar concept, and `shutil` rejects the argument for
+    other formats, so zip archives are simply unpacked as before.
+    """
+    if tarfile.is_tarfile(archive):
+        with tarfile.open(archive) as tf:
+            tf.extractall(dst, filter="data")
+    else:
+        shutil.unpack_archive(archive, dst)
 
 
 def download_to_memory(url: str) -> bytes:

--- a/tools/validate_package.py
+++ b/tools/validate_package.py
@@ -28,7 +28,6 @@ name, or the path to a meta.json file. For example:
 """
 
 import os
-import shutil
 import sys
 import tarfile
 from os.path import join
@@ -118,7 +117,7 @@ def main(pkgs: List[str]) -> None:
             try:
                 archive_fname = download_archive(archive_dir, pkg_name)
                 pkgdir = join(tempdir, validate_tarball(archive_fname))
-                shutil.unpack_archive(archive_fname, tempdir)
+                utils.unpack_archive(archive_fname, tempdir)
                 validate_package(archive_fname, pkgdir, pkg_name)
                 result = utils.gap_exec2(
                     f'ValidatePackagesArchive("{pkgdir}", "{pkg_name}");',


### PR DESCRIPTION
Python 3.12 and 3.13 emit

```
DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives
and reject files or modify their metadata. Use the filter argument to control
this behavior.
```

when `assemble_distro.py` unpacks a package archive. Rather than silence it, this says explicitly what we want, so extraction does not change under us when the default flips.

The filter chosen is `data`, which is the one 3.14 will apply anyway; naming it means extraction behaves identically on every version we support. It also refuses entries that would write outside the destination, which is a reasonable check on archives fetched from package authors.

Two details made this less mechanical than it looks:

- Extraction filters are a tar concept. `shutil.unpack_archive` raises `TypeError: _unpack_zipfile() got an unexpected keyword argument 'filter'` if the argument is passed for a zip. No package currently has `.zip` as its first format, but some do offer one, so unpacking now goes through a small helper in `utils.py` that applies the filter only to tar archives.
- `shutil.unpack_archive` only gained `filter` in 3.12, whereas `TarFile.extractall` got it as far back as 3.8.17/3.11.4. The helper uses `tarfile` directly, which keeps this working on the 3.11 that CI uses.

### Checking that nothing changes

I ran every archive the distribution currently uses through both filters as `extractall` would. None is rejected — including AGT, whose broken symlink `assemble_distro.py` has a workaround for.

Comparing an unfiltered extraction against a `data` extraction of all 156 archives, 7 differ, and only ever in permission bits: `0o664`→`0o644`, `0o444`→`0o644`, `0o777`→`0o755`. No file is added, dropped, or altered in size. Since `assemble_distro.py` calls `normalize_access_permissions()` immediately after unpacking, those differences do not survive: for each of the 7 packages the resulting tree is identical either way, which I verified rather than assumed.

Finally, extracting the same archive under 3.13 and 3.14 gives the same files and no warnings on either, and the zip path still works on both.

The full test suite passes with no warnings left (it previously reported `52 passed, 1 warning`).

Unrelated observation while testing: my local copy of `primgrp-4.0.3.tar.gz` is truncated and fails to open. That predates the atomic-download change in #1464, which would now prevent it; the copy on files.gap-system.org is fine.

AI disclosure: prepared with Claude Code, which wrote the change, ran the verification and drafted this description; reviewed by the pull request author.
