### PR TITLE
tools: Only require a version bump for real releases

### DIFF
--- a/tools/validate_package.g
+++ b/tools/validate_package.g
@@ -78,7 +78,8 @@ end;
 # - the package at <unpacked_dir>/<nam> is not a dev version
 #   (according to its version number),
 # - the version number in <nam>/meta.json is *strictly larger than*
-#   the version number in <nam>/meta.json.old,
+#   the version number in <nam>/meta.json.old, provided the package
+#   actually released something new (see below),
 # - the release date in <nam>/meta.json is *at least* the release date
 #   in <nam>/meta.json.old.
 # - the release date in <nam>/meta.json is not more than one day in the future
@@ -117,7 +118,14 @@ ValidatePackagesArchive := function(unpacked_dir, pkgnames)
       if json_old <> fail then
         json_old := JsonStringToGap(json_old);
       fi;
-      if json_old <> fail and json <> json_old and
+      # A package must not ship different content under a version number it
+      # already used. What tells us it did is a change of the checksums, not a
+      # change of the metadata as a whole: we also edit meta.json ourselves,
+      # e.g. to normalize a field or to add one, and such an edit is not a
+      # release and hence needs no new version number.
+      if json_old <> fail and
+         (json.ArchiveSHA256 <> json_old.ArchiveSHA256 or
+          json.PackageInfoSHA256 <> json_old.PackageInfoSHA256) and
          CompareVersionNumbers(json_old.Version, json.Version) then
         PrintToFormatted("*errout*",
                          Concatenation("\033[33m{}: current release version is {},",


### PR DESCRIPTION
`ValidatePackagesArchive` rejects any pull request that changes a
`meta.json` without increasing the package version:

```
ace: current release version is 5.7.0, but previous release version was 5.7.0, FAILED!
```

The condition is

```gap
if json_old <> fail and json <> json_old and
   CompareVersionNumbers(json_old.Version, json.Version) then
```

i.e. *the metadata changed and the version did not increase*. That is the
right rule for the automatic package update pull requests, where the version
always goes up. But it also catches every change we make to the metadata
ourselves -- normalizing a field, adding a new one, or touching a file to
trigger a test run -- none of which is a release, and none of which needs a
new version number. Since `validate_package.py` exits on the first failure,
the run dies on the first package alphabetically and never looks at the rest.

Seen recently on #1478, which reformats the `Date` of 148 packages, and
earlier on a branch that added a line to `packages/ace/meta.json` to trigger
the package tests.

What the check is really after is a package shipping different content under
a version number it already used. Decide that by comparing the archive and
`PackageInfo.g` checksums instead of the metadata record as a whole. Behaviour
is unchanged for everything except our own edits:

| | before | after |
| --- | --- | --- |
| new package, no old metadata | pass | pass |
| normal update 1.0 -> 1.1 | pass | pass |
| date reformatted, same version | **fail** | pass |
| field added by our tooling, same version | **fail** | pass |
| archive re-released under same version | fail | fail |
| `PackageInfo.g` changed, same version | fail | fail |
| version decreased | fail | fail |

Note that this is not exercised by CI here: the PR workflow only triggers on
`packages/*/meta.json`, and the Python tool tests do not cover the GAP code.
Rebasing #1478 on top of this is the real test.

AI disclosure: Claude Code (Claude Opus 5) diagnosed the CI failure and wrote
this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
