### PR TITLE
tests: Detect syntax warnings when loading packages

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -433,6 +433,25 @@ jobs:
                 FORCE_QUIT_GAP(res);
                 "
 
+      # Loading a package can print syntax errors and warnings without loading
+      # itself failing, so neither of the two steps above notices them. Look
+      # for them in a separate step, which we can do in a fresh GAP session
+      # without the workarounds above, as those are only needed for the tests.
+      #
+      # We only load with 'OnlyNeeded': fewer global variables are bound then
+      # than with a default load, so this is the setting in which GAP reports
+      # the most problems.
+      - name: "Check for syntax warnings when loading"
+        timeout-minutes: 10
+        if: always()
+        id: syntax-warnings
+        run: |
+          PKG=${{ matrix.package }}
+          gap -A --quitonbreak -r -c "
+                Read(\"tools/check_syntax_warnings.g\");
+                FORCE_QUIT_GAP(LoadPackageAndCheckSyntax(\"$PKG\" : OnlyNeeded));
+                "
+
   report:
     name: "Generate report"
     needs: [build, test-package]

--- a/README.md
+++ b/README.md
@@ -218,3 +218,8 @@ Some more details:
     currently are lenient there and include custom treatment for a bunch of
     packages (for details see the "Run tests with OnlyNeeded" step in
     `.github/workflows/test-all.yml`)
+  - start GAP, do `LoadPackage("pkgname" : OnlyNeeded)` and check whether GAP
+    printed any syntax errors or warnings for files of `pkgname` while doing so
+    - such messages do not make loading fail, so nothing else notices them, but
+      they look alarming to users and almost always indicate a genuine mistake
+      in the package, which we then report upstream

--- a/tools/check_syntax_warnings.g
+++ b/tools/check_syntax_warnings.g
@@ -1,0 +1,80 @@
+#############################################################################
+##
+##  This file is part of GAP, a system for computational discrete algebra.
+##
+##  Copyright of GAP belongs to its developers, whose names are too numerous
+##  to list here. Please refer to the COPYRIGHT file for details.
+##
+##  SPDX-License-Identifier: GPL-2.0-or-later
+##
+##  While reading a file, GAP reports problems such as a reference to an
+##  unbound global variable as a "Syntax warning", but then carries on. Thus
+##  loading a package with such a problem still succeeds and none of our tests
+##  notices, even though the message looks alarming to users and almost always
+##  indicates a genuine mistake in the package. The code below loads a package
+##  and turns any such message about one of the package's own files into a
+##  failure, so that we can report the problem upstream.
+##
+
+# Load the package <pkgname> and report all syntax errors and warnings GAP
+# printed for files belonging to that package. Returns `true` if there were
+# none, and `false` otherwise.
+#
+# Options are passed on to `LoadPackage`, so that
+#     LoadPackageAndCheckSyntax("lpres" : OnlyNeeded);
+# does the same as `LoadPackage("lpres" : OnlyNeeded);` plus the extra check.
+LoadPackageAndCheckSyntax := function(pkgname)
+  local out, stream, paths, lines, problems, formatting, i, line;
+
+  out := "";
+  stream := OutputTextString(out, true);
+  # `OutputLogTo` logs rather than redirects, so the output still shows up in
+  # the CI log as usual. It also covers the syntax messages, even though GAP
+  # prints those to stderr.
+  OutputLogTo(stream);
+  LoadPackage(pkgname);
+  OutputLogTo();
+  CloseStream(stream);
+
+  # What is logged is the output as it appeared on the screen, i.e. broken
+  # into lines of screen width, with a backslash marking each break. Undo
+  # that, as it can tear a file name apart.
+  out := ReplacedString(out, "\\\n", "");
+
+  # Only complain about the package's own files: problems in files of its
+  # dependencies are found and reported when those packages are tested.
+  paths := [];
+  if IsBound(GAPInfo.PackagesInfo.(LowercaseString(pkgname))) then
+    paths := List(GAPInfo.PackagesInfo.(LowercaseString(pkgname)),
+                  info -> info.InstallationPath);
+  fi;
+
+  # Such a message consists of a line naming the problem and the file it
+  # occurred in, followed by the offending source line and a marker line.
+  problems := [];
+  lines := SplitString(out, "", "\n");
+  for i in [1 .. Length(lines)] do
+    line := lines[i];
+    if (StartsWith(line, "Syntax error:") or StartsWith(line, "Syntax warning:"))
+       and ForAny(paths, path -> PositionSublist(line, path) <> fail) then
+      Append(problems, lines{[i .. Minimum(i + 2, Length(lines))]});
+    fi;
+  od;
+
+  if IsEmpty(problems) then
+    return true;
+  fi;
+
+  # Report the problems, with line breaking turned off so that GAP does not
+  # tear the file names apart again.
+  formatting := PrintFormattingStatus("*stdout*");
+  SetPrintFormattingStatus("*stdout*", false);
+  Print("::error::Syntax errors or warnings occurred while loading ",
+        pkgname, "\n");
+  for line in problems do
+    Print(line, "\n");
+  od;
+  SetPrintFormattingStatus("*stdout*", formatting);
+
+  return false;
+end;


### PR DESCRIPTION
When GAP encounters e.g. a reference to an unbound global variable
while reading a file, it prints a "Syntax warning" and carries on.
Loading the package thus still succeeds and no test notices, even
though such a message looks alarming to users and almost always
points at a genuine mistake in the package.

Each package job now loads the package once more in a fresh GAP
session, with only its needed dependencies, and fails if GAP printed
any syntax error or warning for one of the package's own files.
Messages about files of its dependencies are ignored, since those
are reported when the respective package is tested.

Assistance by AI: this change, including its documentation, was
drafted by Claude Code and reviewed by a human.

Fixes #204

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
