### PR TITLE
tools: Don't let one bad date stop the update scan

### DIFF
--- a/tools/scan_for_updates.py
+++ b/tools/scan_for_updates.py
@@ -109,15 +109,22 @@ def import_packages(pkginfo_paths: List[str]) -> None:
     pkginfos = parse_pkginfo_files(pkginfo_paths)
     for pkg_json in pkginfos:
         pkgname = pkg_json["PackageName"].lower()
+        # Store the release date in ISO format, whichever of the two formats
+        # GAP accepts the PackageInfo.g happened to use. If we cannot make
+        # sense of the date at all, skip just this one package: its author
+        # gets to hear about it in the pull request for their package, while
+        # updates to all other packages must keep flowing regardless.
+        try:
+            pkg_json["Date"] = utils.normalize_date(pkg_json["Date"])
+        except ValueError as e:
+            warning(f"{pkgname}: {e}; not importing this update")
+            continue
         # Do this before anything else reads the format: the archive we
         # download, and hence the checksum and size we record, must be the one
         # our consumers will use.
         pkg_json["ArchiveFormats"] = utils.sort_archive_formats(
             pkg_json["ArchiveFormats"]
         )
-        # Store the release date in ISO format, whichever of the two formats
-        # GAP accepts the PackageInfo.g happened to use.
-        pkg_json["Date"] = utils.normalize_date(pkg_json["Date"])
         url = archive_url(pkg_json)
         archive_fname = join(archive_dir, url.split("/")[-1])
         try:

--- a/tools/tests/test_scan_for_updates.py
+++ b/tools/tests/test_scan_for_updates.py
@@ -146,3 +146,41 @@ def test_import_packages_records_archive_size(ensure_in_tests_dir, tmpdir):
 
     shutil.rmtree("packages/testpkg")
     shutil.rmtree("_archives")
+
+
+def test_import_packages_skips_unparseable_dates(ensure_in_tests_dir, tmpdir):
+    # A PackageInfo.g whose Date we cannot parse is skipped -- but only that
+    # one package: everything else in the same batch is imported as usual.
+    bad_pkg_json = {
+        "ArchiveFormats": ".tar.gz",
+        "ArchiveURL": "https://example.com/baddatepkg-1.0",
+        "Date": "07/20/2026",  # month and day the American way round
+        "PackageName": "BadDatePkg",
+        "Version": "1.0",
+    }
+    good_pkg_json = {
+        "ArchiveFormats": ".tar.gz",
+        "ArchiveURL": "https://example.com/gooddatepkg-1.0",
+        "Date": "20/07/2026",
+        "PackageName": "GoodDatePkg",
+        "Version": "1.0",
+    }
+
+    def fake_download(_url, dst):
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        with open(dst, "wb") as f:
+            f.write(b"archive-bytes-go-here")
+
+    try:
+        with mock.patch(
+            "scan_for_updates.parse_pkginfo_files",
+            return_value=[bad_pkg_json, good_pkg_json],
+        ), mock.patch("scan_for_updates.utils.download", side_effect=fake_download):
+            import_packages(["bad.g", "good.g"])
+
+        assert not exists("packages/baddatepkg")
+        assert metadata("gooddatepkg")["Date"] == "2026-07-20"
+    finally:
+        shutil.rmtree("packages/baddatepkg", ignore_errors=True)
+        shutil.rmtree("packages/gooddatepkg", ignore_errors=True)
+        shutil.rmtree("_archives", ignore_errors=True)

--- a/tools/tests/test_utils.py
+++ b/tools/tests/test_utils.py
@@ -43,9 +43,8 @@ def test_normalize_date_rejects_bad_dates():
         "31/02/2025",  # not a real date
         "2025-02-31",
     ]:
-        with pytest.raises(SystemExit) as e:
+        with pytest.raises(ValueError):
             normalize_date(date)
-        assert e.value.code == 1, date
 
 
 def test_distributed_metadata_uses_iso_dates():

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -168,15 +168,17 @@ def normalize_date(date: str) -> str:
     `package-infos.json` derived from it -- never have to guess which of the
     two they are looking at, and can compare dates by comparing strings.
 
-    An unparseable date is an error rather than something we pass through
-    unchanged: silently keeping it would defeat the point of normalizing.
+    An unparseable date raises `ValueError` rather than being passed through
+    unchanged: silently keeping it would defeat the point of normalizing. It is
+    up to the caller to decide how far the damage reaches -- a typo in a single
+    `PackageInfo.g` should not stop us from processing the other packages.
     """
     for fmt in DATE_FORMATS:
         try:
             return datetime.strptime(date, fmt).strftime(DATE_FORMATS[0])
         except ValueError:
             pass
-    error(f"cannot parse date {date!r}, expected YYYY-MM-DD or DD/MM/YYYY")
+    raise ValueError(f"cannot parse date {date!r}, expected YYYY-MM-DD or DD/MM/YYYY")
 
 
 # Archive formats to put first, in order of preference. Our own tooling uses

--- a/tools/validate_package.py
+++ b/tools/validate_package.py
@@ -108,8 +108,13 @@ def validate_package(archive_fname: str, pkgdir: str, pkg_name: str) -> None:
         error(f"{pkg_name}: ArchiveSHA256 is not the SHA256 of {archive_fname}")
 
     # `scan_for_updates.py` stores the release date in ISO format; catch
-    # hand-edited metadata that reverts to the traditional DD/MM/YYYY
-    if pkg_json["Date"] != utils.normalize_date(pkg_json["Date"]):
+    # hand-edited metadata that reverts to the traditional DD/MM/YYYY, or that
+    # contains a date we cannot make sense of at all
+    try:
+        iso_date = utils.normalize_date(pkg_json["Date"])
+    except ValueError as e:
+        error(f"{pkg_name}: {e}")
+    if pkg_json["Date"] != iso_date:
         error(f"{pkg_name}: Date {pkg_json['Date']} is not in YYYY-MM-DD format")
 
 


### PR DESCRIPTION
Since we started normalizing release dates in #1478, a `PackageInfo.g`
with a date in neither of the two formats GAP accepts aborted the whole
run of `scan_for_updates.py`: the error was reported by exiting the
process, and that happened while importing the updates the scan had
already found. As a result a single package with a typo in its date --
currently `07/20/2026`, see #1449 -- held up the pull requests for every
other updated package, and the "Scan for updates" job failed every hour.

`normalize_date` now raises `ValueError` instead of exiting, and
`import_packages` skips just the package whose date it cannot parse,
warning about it and leaving that `meta.json` untouched, so the bad
update is not ingested. Validation of an existing `meta.json` in
`validate_package.py` still fails hard, as before.

Note that a package with a broken date now gets no pull request at all,
so the warning in the scan log is the only signal. If we would rather
keep telling the author about it, that is worth a follow-up.

Fixes #1482

AI disclosure: Claude Code (Opus 5) drafted this change and its tests.