### PR TITLE
tools: Let scan_for_updates.py read a local PackageInfo.g

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,18 @@ Some more details:
     ./tools/scan_for_updates.py example
     ./tools/validate_package.py example
     ```
-    However this only works if you already made a release, as it downloads the metadata
-    from the `PackageInfoURL` (see also <https://github.com/gap-system/PackageDistro/issues/1024>).
+    This downloads the metadata from the `PackageInfoURL`, and hence only works once
+    you made a release. To try out an update beforehand, pass the directory holding
+    the `PackageInfo.g` of your working copy (or that file itself) instead of the
+    package name, and the metadata is read from there:
+    ```
+    ./tools/scan_for_updates.py path/to/example
+    ./tools/validate_package.py example
+    ```
+    Note that the source archive is still fetched from `ArchiveURL`: until you
+    publish it, `scan_for_updates.py` warns and records `FAIL` as its checksum, and
+    `validate_package.py` fails outright because it cannot download the archive it
+    is supposed to check.
   - The checks this perform include
       - check output of GAP function `ValidatePackageInfo`
       - verify version is greater than previous version and does not contain `dev`

--- a/tools/scan_for_updates.py
+++ b/tools/scan_for_updates.py
@@ -21,6 +21,16 @@ and do the following:
 
     TODO
 
+Usage:
+
+    scan_for_updates.py [PKGNAME...]
+    scan_for_updates.py PATH...
+
+Without arguments every package of the distribution is scanned for a new
+release, with package names only those. Given paths instead -- each either a
+directory containing a `PackageInfo.g` or such a file itself -- the metadata is
+read from there rather than downloaded, which allows trying out a package
+update before it is released.
 """
 
 import hashlib
@@ -145,17 +155,59 @@ def import_packages(pkginfo_paths: List[str]) -> None:
             f.write("\n")
 
 
-def main(pkg_names: List[str]) -> None:
-    print("Scanning for updates...")
-    if len(pkg_names) == 0:
-        pkg_names = all_packages()
-    updated_pkgs = scan_for_updates(pkg_names)
-    if len(updated_pkgs) == 0:
-        print("None found")
-        return
+def local_pkginfo(arg: str) -> Optional[str]:
+    """The `PackageInfo.g` that `arg` points at, or None if `arg` is a package name.
+
+    Naming a path instead of a package lets one import a package straight from
+    a working copy, before any release has been made and hence before there is
+    anything to download from its `PackageInfoURL`. The path may be either the
+    directory holding the `PackageInfo.g`, or that file itself.
+    """
+    if os.path.isfile(metadata_fname(normalize_pkg_name(arg))):
+        # "packages/aclib" and "packages/aclib/meta.json" name a package of the
+        # distribution, even though they are paths on disk as well.
+        return None
+    if os.path.isdir(arg):
+        pkginfo = join(arg, "PackageInfo.g")
+        if not os.path.isfile(pkginfo):
+            error(f"{arg}: directory contains no PackageInfo.g")
+        return pkginfo
+    if os.path.isfile(arg):
+        return arg
+    if os.path.dirname(arg):
+        # Anything with a directory part was meant as a path, so say that it is
+        # not there rather than going on to look for a package of that name.
+        error(f"{arg}: no such file or directory")
+    return None
+
+
+def main(args: List[str]) -> None:
+    pkginfo_paths = []
+    pkg_names = []
+    for arg in args:
+        pkginfo = local_pkginfo(arg)
+        if pkginfo is None:
+            pkg_names.append(normalize_pkg_name(arg))
+        else:
+            pkginfo_paths.append(pkginfo)
+
+    if pkginfo_paths:
+        if pkg_names:
+            error("cannot mix package names and paths to local packages")
+        for pkginfo in pkginfo_paths:
+            notice(f"importing {pkginfo}")
+    else:
+        print("Scanning for updates...")
+        if len(pkg_names) == 0:
+            pkg_names = all_packages()
+        pkginfo_paths = scan_for_updates(pkg_names)
+        if len(pkginfo_paths) == 0:
+            print("None found")
+            return
+
     print("Updating meta.json files...")
-    import_packages(updated_pkgs)
+    import_packages(pkginfo_paths)
 
 
 if __name__ == "__main__":
-    main([normalize_pkg_name(x) for x in sys.argv[1:]])
+    main(sys.argv[1:])

--- a/tools/tests/test_scan_for_updates.py
+++ b/tools/tests/test_scan_for_updates.py
@@ -22,6 +22,7 @@ sys.path.insert(
 
 from scan_for_updates import (
     import_packages,
+    local_pkginfo,
     main,
     scan_for_one_update,
     scan_for_updates,
@@ -115,6 +116,65 @@ def test_main_again(ensure_in_tests_dir):
         main(["aclib"])
     finally:
         reset()
+
+
+@pytest.fixture
+def local_pkg(tmpdir):
+    """A directory holding a PackageInfo.g, as an unreleased package would."""
+    pkgdir = join(str(tmpdir), "my_gap_package")
+    os.mkdir(pkgdir)
+    pkginfo = join(pkgdir, "PackageInfo.g")
+    with open(pkginfo, "w", encoding="utf-8") as f:
+        f.write('SetPackageInfo( rec( PackageName := "MyGapPackage" ) );\n')
+    return pkgdir, pkginfo
+
+
+def test_local_pkginfo_accepts_directory_or_file(ensure_in_tests_dir, local_pkg):
+    pkgdir, pkginfo = local_pkg
+
+    assert local_pkginfo(pkgdir) == pkginfo
+    assert local_pkginfo(pkginfo) == pkginfo
+
+
+def test_local_pkginfo_leaves_package_names_alone(ensure_in_tests_dir):
+    # These name a package of the distribution; the latter two are paths on
+    # disk as well, and must not be mistaken for a local package.
+    assert local_pkginfo("aclib") is None
+    assert local_pkginfo("packages/aclib") is None
+    assert local_pkginfo("packages/aclib/meta.json") is None
+
+
+def test_local_pkginfo_rejects_directory_without_pkginfo(ensure_in_tests_dir, tmpdir):
+    with pytest.raises(SystemExit) as e:
+        local_pkginfo(str(tmpdir))
+    assert e.value.code == 1
+
+
+def test_local_pkginfo_rejects_nonexistent_path(ensure_in_tests_dir, tmpdir):
+    with pytest.raises(SystemExit) as e:
+        local_pkginfo(join(str(tmpdir), "no", "such", "package"))
+    assert e.value.code == 1
+
+
+def test_main_imports_local_package_without_scanning(ensure_in_tests_dir, local_pkg):
+    pkgdir, pkginfo = local_pkg
+
+    with mock.patch("scan_for_updates.import_packages") as fake_import, mock.patch(
+        "scan_for_updates.scan_for_updates"
+    ) as fake_scan:
+        main([pkgdir])
+
+    # The whole point: nothing is downloaded, the local file is imported as is.
+    fake_scan.assert_not_called()
+    fake_import.assert_called_once_with([pkginfo])
+
+
+def test_main_rejects_mixing_names_and_paths(ensure_in_tests_dir, local_pkg):
+    pkgdir, _ = local_pkg
+
+    with pytest.raises(SystemExit) as e:
+        main([pkgdir, "aclib"])
+    assert e.value.code == 1
 
 
 def test_import_packages_records_archive_size(ensure_in_tests_dir, tmpdir):


### PR DESCRIPTION
Allow passing a path to a local package instead of a package name:

```
./tools/scan_for_updates.py path/to/my_gap_package
```

The path may be either the directory holding the `PackageInfo.g`, or that
file itself. Its metadata is then read from disk rather than downloaded
from the `PackageInfoURL`, so that a package author can see what the
distribution will make of an update before publishing it.

Arguments naming a package of the distribution keep their meaning. That
needs a little care, because the `packages/NAME` and
`packages/NAME/meta.json` forms that `normalize_pkg_name` accepts are
paths on disk as well: an argument is therefore only treated as a local
package once it turns out not to name a package of the distribution.

Names and paths cannot be mixed. A path that does not exist, and a
directory without a `PackageInfo.g`, are reported as such instead of
being taken for a package name -- the latter only for arguments with a
directory part, so that a mistyped package name still produces the usual
error about the missing `meta.json`.

Note that only the metadata comes from disk. The source archive is still
fetched from `ArchiveURL`, so until it is published `scan_for_updates.py`
warns and records `FAIL` as its checksum, and `validate_package.py` fails
outright because it cannot download the archive it is supposed to check.
The README section that used to point at this issue as a known limitation
now documents the new usage, including that caveat.

Fixes #1024

## AI disclosure

Claude Code (Claude Opus 5) wrote the change, the tests, and this
description, and is recorded as a co-author on the commit.
