### PR TITLE
README: Point at the three package lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@ contains the metadata of all the GAP packages in the distribution. We also
 upload snapshots of the package distribution to appropriate release tags
 on this repository.
 
-An overview of all packages in the distribution, with their versions, release
-dates and links, is published at
-<https://gap-system.github.io/PackageDistro/packages/>.
+## Package lists
+
+- <https://gap-system.github.io/PackageDistro/packages/>: all packages
+  currently in this distribution, with their versions and release dates
+- <https://www.gap-system.org/packages/>: the packages shipped with the latest
+  GAP release
+- <https://gap-packages.github.io>: further GAP packages that are not part of
+  the distribution
 
 ## High-level status dashboard
 


### PR DESCRIPTION
A reader looking for "which packages are there" currently has to know
about three different lists. This adds a short section naming all three,
each with a one line explanation of what it actually covers:

- the new distribution overview, i.e. what is in this repository,
- the list on the GAP website, i.e. what ships with the latest release,
- gap-packages.github.io, i.e. packages outside the distribution.

The standalone link to the overview page added in #1481 is subsumed by
that section.

AI disclosure: prepared with the help of Claude Code (Opus 5), which
wrote the section. It is a co-author of the commit.