### PR TITLE
tools: Check the links in package documentation

### DIFF
--- a/tools/tests/test_validate_package.py
+++ b/tools/tests/test_validate_package.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=no-name-in-module, missing-function-docstring
+# pylint: disable=missing-class-docstring, invalid-name, redefined-outer-name
+
+"""
+This module contains some tests for the validate_package.py script
+"""
+
+import os
+import sys
+from os.path import join
+
+import pytest
+
+sys.path.insert(
+    0, "/".join(os.path.dirname(os.path.realpath(__file__)).split("/")[:-1])
+)
+
+from validate_package import check_html_links, check_link
+
+# Where a package manual usually keeps its chapters, and hence the vantage
+# point from which most links are resolved.
+CHAPTER = join("doc", "chap1.html")
+
+
+@pytest.mark.parametrize(
+    "href",
+    [
+        "https://www.gap-system.org/",
+        "http://www.gap-system.org/",
+        "mailto:support@gap-system.org",
+        "#X7DC99E4284093FBB",
+        "",
+        "chap2.html",
+        "chap2.html#X7DC99E4284093FBB",
+        "../README.md",
+        # A package manual reaches the GAP reference manual, and the manual of
+        # another package, by climbing out of its own directory.
+        "../../../doc/ref/chap37.html",
+        "../../../pkg/gapdoc/doc/chap6.html",
+    ],
+)
+def test_check_link_accepts(href):
+    assert check_link(href, CHAPTER) is None
+
+
+@pytest.mark.parametrize(
+    "href",
+    [
+        # An absolute path only ever resolves on the machine that built the
+        # documentation.
+        "/Users/someone/gap/doc/ref/chap37.html",
+        "/doc/ref/chap1.html",
+        "//www.gap-system.org/doc",
+        "C:\\gap\\doc\\ref.html",
+        # Schemes we do not accept ...
+        "file:///etc/passwd",
+        "ftp://ftp.example.com/paper.dvi.gz",
+        # ... including the marker that GAP's own etc/convert.pl leaves behind
+        # for a cross reference it could not resolve.
+        "badlink:ref:Matrix Groups in Characteristic 0",
+        # Climbing further than <gaproot>.
+        "../../../../../../etc/passwd",
+    ],
+)
+def test_check_link_rejects(href):
+    assert check_link(href, CHAPTER) is not None
+
+
+def test_check_link_counts_from_the_file_that_contains_it():
+    # The same link is fine from a chapter one level down, and leaves the GAP
+    # installation from a file at the top of the package.
+    assert check_link("../../../doc/ref/chap37.html", CHAPTER) is None
+    assert check_link("../../../doc/ref/chap37.html", "index.html") is not None
+
+
+def write_html(path, body):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(f"<html><body>{body}</body></html>\n")
+
+
+def test_check_html_links_accepts_a_clean_package(tmpdir):
+    pkgdir = str(tmpdir)
+    write_html(
+        join(pkgdir, "doc", "chap1.html"),
+        '<a href="chap2.html">next</a>'
+        '<a href="../../../doc/ref/chap37.html">the reference manual</a>'
+        '<a href="https://www.gap-system.org/">GAP</a>',
+    )
+    # Files that are not HTML are none of our business.
+    with open(join(pkgdir, "PackageInfo.g"), "w", encoding="utf-8") as f:
+        f.write('SetPackageInfo( rec( PackageName := "<a href=\\"/bad\\">" ) );\n')
+
+    check_html_links(pkgdir, "testpkg")
+
+
+def test_check_html_links_rejects_bad_links(tmpdir, capsys):
+    pkgdir = str(tmpdir)
+    write_html(join(pkgdir, "doc", "chap1.html"), '<a href="/etc/passwd">boom</a>')
+
+    with pytest.raises(SystemExit) as e:
+        check_html_links(pkgdir, "testpkg")
+    assert e.value.code == 1
+
+    # The author is told which file to look at, and where in it.
+    reported = capsys.readouterr().err
+    assert join("doc", "chap1.html") + ":1:" in reported
+    assert "/etc/passwd" in reported
+
+
+def test_check_html_links_searches_the_whole_package(tmpdir):
+    # Documentation is not always below doc/: old style manuals live in htm/,
+    # and some packages ship whole web pages alongside.
+    pkgdir = str(tmpdir)
+    write_html(join(pkgdir, "htm", "CHAP001.htm"), '<a href="badlink:ref:Foo">x</a>')
+
+    with pytest.raises(SystemExit) as e:
+        check_html_links(pkgdir, "testpkg")
+    assert e.value.code == 1
+
+
+def test_check_html_links_caps_the_number_it_reports(tmpdir, capsys):
+    pkgdir = str(tmpdir)
+    write_html(
+        join(pkgdir, "doc", "chap1.html"),
+        "".join(f'<a href="/bad/{i}">x</a>' for i in range(50)),
+    )
+
+    with pytest.raises(SystemExit):
+        check_html_links(pkgdir, "testpkg")
+    assert "and 30 more" in capsys.readouterr().err

--- a/tools/validate_package.py
+++ b/tools/validate_package.py
@@ -30,9 +30,11 @@ name, or the path to a meta.json file. For example:
 import os
 import sys
 import tarfile
+import urllib.parse
+from html.parser import HTMLParser
 from os.path import join
 from tempfile import TemporaryDirectory
-from typing import List
+from typing import List, Optional, Tuple
 
 import utils
 from download_packages import download_archive
@@ -82,6 +84,114 @@ def validate_tarball(filename: str) -> str:
         return basedir
 
 
+HTML_SUFFIXES = (".html", ".htm", ".xhtml")
+
+# The only URL schemes a link in package documentation may use. Anything else
+# is either unusable offline (`file:`), no longer something we want to send
+# readers to (`ftp:`), or not a scheme at all but a marker left behind by a
+# documentation tool: GAP's own `etc/convert.pl` turns a cross reference it
+# cannot resolve into `badlink:...`.
+ALLOWED_SCHEMES = ("http", "https", "mailto")
+
+# Package documentation is installed at `<gaproot>/pkg/<name>/`, so a relative
+# link may climb two levels above the package directory -- that is how a manual
+# links into the GAP reference manual, or into another package -- but no
+# further, as that would leave the GAP installation altogether.
+GAPROOT_HEADROOM = 2
+
+# A package with a systematic problem produces one complaint per link, of which
+# a handful tell the author everything they need to know.
+MAX_REPORTED_LINKS = 20
+
+
+class LinkExtractor(HTMLParser):
+    """Collects the target of every `<a href="...">` along with its line."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.links: List[Tuple[int, str]] = []
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        if tag != "a":
+            return
+        for name, value in attrs:
+            if name == "href" and value is not None:
+                self.links.append((self.getpos()[0], value))
+
+
+def check_link(href: str, relpath: str) -> Optional[str]:
+    """Say what is wrong with the link `href`, or None if it is acceptable.
+
+    `relpath` is the path of the HTML file containing the link, relative to
+    the package directory; it decides how far up a relative link reaches.
+
+    Only links that are wrong wherever the package is installed are rejected.
+    Whether a relative link points at a file that actually exists is
+    deliberately not checked: some packages generate parts of their
+    documentation only after installation, so that check needs to be
+    introduced more carefully.
+    """
+    href = href.strip()
+    if not href or href.startswith("#"):
+        return None
+
+    parsed = urllib.parse.urlparse(href)
+    if parsed.scheme:
+        if parsed.scheme in ALLOWED_SCHEMES:
+            return None
+        if len(parsed.scheme) == 1:
+            # A Windows drive letter, e.g. "C:\gap\doc\ref.html".
+            return f"absolute path: {href}"
+        return f"URL scheme {parsed.scheme}: is not allowed: {href}"
+    if href.startswith("/"):
+        # Both "/doc/ref" and the protocol relative "//host/doc" only ever
+        # resolve to something outside the GAP installation.
+        return f"absolute path: {href}"
+
+    target = urllib.parse.unquote(parsed.path)
+    if not target:
+        return None
+    resolved = os.path.normpath(os.path.join(os.path.dirname(relpath), target))
+    up = 0
+    for part in resolved.split(os.sep):
+        if part != "..":
+            break
+        up += 1
+    if up > GAPROOT_HEADROOM:
+        return f"link leaves the GAP installation: {href}"
+    return None
+
+
+def check_html_links(pkgdir: str, pkg_name: str) -> None:
+    """Check the links in all HTML files shipped by a package."""
+    problems = []
+    for dirpath, dirnames, filenames in os.walk(pkgdir):
+        dirnames.sort()
+        for name in sorted(filenames):
+            if not name.lower().endswith(HTML_SUFFIXES):
+                continue
+            path = join(dirpath, name)
+            relpath = os.path.relpath(path, pkgdir)
+            with open(path, "rb") as f:
+                # Package documentation is not always valid UTF-8, and a byte
+                # we cannot decode is no reason to reject a package; it cannot
+                # be part of a link we would complain about either.
+                text = f.read().decode("utf-8", errors="replace")
+            parser = LinkExtractor()
+            parser.feed(text)
+            for line, href in parser.links:
+                reason = check_link(href, relpath)
+                if reason is not None:
+                    problems.append(f"{relpath}:{line}: {reason}")
+
+    if problems:
+        shown = problems[:MAX_REPORTED_LINKS]
+        if len(problems) > len(shown):
+            shown.append(f"... and {len(problems) - len(shown)} more")
+        details = "\n  ".join(shown)
+        error(f"{pkg_name}: bad links in HTML documentation:\n  {details}")
+
+
 def validate_package(archive_fname: str, pkgdir: str, pkg_name: str) -> None:
     pkg_json = metadata(pkg_name)
 
@@ -116,6 +226,8 @@ def validate_package(archive_fname: str, pkgdir: str, pkg_name: str) -> None:
         error(f"{pkg_name}: {e}")
     if pkg_json["Date"] != iso_date:
         error(f"{pkg_name}: Date {pkg_json['Date']} is not in YYYY-MM-DD format")
+
+    check_html_links(pkgdir, pkg_name)
 
 
 def main(pkgs: List[str]) -> None:


### PR DESCRIPTION
Check every `<a href>` in every HTML file of a package archive, and
reject the links that are wrong no matter where the package is
installed:

| rejected | example |
| --- | --- |
| absolute path | `/Users/someone/gap/doc/ref/chap37.html` |
| protocol relative | `//host/doc` |
| Windows drive letter | `C:\gap\doc\ref.html` |
| scheme other than http, https, mailto | `file://…`, `ftp://…`, `badlink:…` |
| climbs out of the GAP installation | `../../../../../../etc/passwd` |

The check runs inside `validate_package()`, which has the archive
unpacked already, so it costs no extra download.

Relative links get two levels of headroom above the package directory:
packages are installed at `<gaproot>/pkg/<name>/`, which is what makes
`../../../doc/ref/chap37.html` into the reference manual, or
`../../../pkg/gapdoc/doc/chap6.html` into another package, legal while
anything deeper is not. The headroom is counted from the file holding
the link, so the same href is fine in `doc/chap1.html` and rejected in
`index.html`.

Rejecting foreign schemes also catches `badlink:...`, which is not a
scheme at all but the marker that GAP's own `etc/convert.pl` leaves
behind for a cross reference it could not resolve.

### Effect on the distribution

Running the check over all 172 packages currently in the distribution:
166 pass. The other six carry ten links between them:

| package | links |
| --- | --- |
| crystcat | 3 × `badlink:` |
| SymbCompCC | 2 × `badlink:` |
| FactInt | 2 × `ftp:` |
| CaratInterface, classicpres, xgap | 1 × `badlink:` each |

As validation only ever runs on packages that are added or updated,
nothing is blocked today; these six are asked to fix their
documentation when they next release.

### Deliberately not checked yet

Whether a relative link points at a file that exists. That rule finds
the most genuine mistakes -- LaTeX macros leaking into an href,
`<a href="codecov.io">` silently becoming a relative link, missing
images -- but `ctbllib` links to pages its own README tells the user to
generate after installation, so as a hard error it would reject a
package that is doing nothing wrong. It needs a gentler introduction
than this pull request offers, and #202 stays open for it, along with
the checking of external URLs.

### Testing

Besides the unit tests, the check was run over the unpacked archives of
all 172 packages; the six failures above are the complete list, and no
package failed for a reason that turned out to be spurious.

See #202

## AI disclosure

Claude Code (Claude Opus 5) investigated the issue, wrote the change and
the tests, and drafted this description. It is recorded as a co-author on
the commit.
