### PR TITLE
Add PerfGrp to the required packages

### DIFF
--- a/tools/assemble_distro.py
+++ b/tools/assemble_distro.py
@@ -150,7 +150,7 @@ def main() -> None:
         "packages-required.tar.gz",
         archive_dir,
         release_dir,
-        ["gapdoc", "primgrp", "smallgrp", "transgrp"],
+        ["gapdoc", "perfgrp", "primgrp", "smallgrp", "transgrp"],
     )
 
     # Make package-infos.json


### PR DESCRIPTION
GAP 4.17 will not start without PerfGrp, since the library of perfect
groups moved out of the core system into that package
(gap-system/gap#6488). `packages-required.tar.gz` so far still held only
the four packages needed by earlier GAP versions, so every CI job that
bootstraps the required set fails with

    Error, failed to load needed package 'perfgrp' (version >= 1.0)

A new `latest` release is needed for this to take effect.

Prepared with Claude Code (Claude Opus 5), which diagnosed the CI
failures and made the change.
