### PR TITLE
ci: Make report job resilient to API failures

### DIFF
--- a/tools/generate_test_status.py
+++ b/tools/generate_test_status.py
@@ -29,11 +29,15 @@ import glob
 import json
 import os
 import sys
+import time
 from datetime import datetime
 from typing import Any, Callable, Dict, List, NotRequired, TypedDict
 
 import requests
-from utils import error, metadata, normalize_pkg_name, warning
+from utils import _should_retry, error, metadata, normalize_pkg_name, warning
+
+GITHUB_API_ATTEMPTS = 4
+GITHUB_API_TIMEOUT = (30, 60)
 
 
 class JobInfo(TypedDict):
@@ -61,21 +65,28 @@ def fetch_jobs(
     run_id: str,
     get: Callable[..., requests.Response] = requests.get,
 ) -> List[Dict[str, Any]]:
-    # Use filter=all so rerunning a single matrix job still lets us see the
-    # jobs from previous attempts of the same workflow run.
+    # `latest` gives us one job per name after a partial rerun, without making
+    # GitHub construct and paginate responses containing every prior attempt.
+    # Smaller pages also avoid intermittent gateway errors seen on large runs.
     url = (
         f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs"
-        "?simple=yes&filter=all&per_page=100&page=1"
+        "?simple=yes&filter=latest&per_page=50&page=1"
     )
     headers = github_headers(git_token)
-    res = get(url, headers=headers)
-    res.raise_for_status()
-    jobs_list = response_jobs(res, url)
-    while "next" in res.links.keys():
-        url = res.links["next"]["url"]
-        res = get(url, headers=headers)
-        res.raise_for_status()
+    jobs_list: List[Dict[str, Any]] = []
+    while url:
+        for attempt in range(1, GITHUB_API_ATTEMPTS + 1):
+            try:
+                res = get(url, headers=headers, timeout=GITHUB_API_TIMEOUT)
+                res.raise_for_status()
+                break
+            except requests.RequestException as exc:
+                if attempt == GITHUB_API_ATTEMPTS or not _should_retry(exc):
+                    raise
+                warning(f'GitHub API request for "{url}" failed ({exc}), retrying')
+                time.sleep(2**attempt)
         jobs_list.extend(response_jobs(res, url))
+        url = res.links.get("next", {}).get("url", "")
     return jobs_list
 
 
@@ -146,8 +157,8 @@ def main(argv: List[str]) -> int:
     jobs_list = fetch_jobs(git_token, repo, run_id)
 
     # Turn list of jobs into a dictionary containing only the relevant data.
-    # With filter=all a rerun may contain multiple jobs with the same name, so
-    # keep the most recent one according to completed_at.
+    # Keep the most recent job defensively in case the API returns duplicate
+    # names despite filter=latest.
     jobs_dict: Dict[str, JobInfo] = {}
     for raw_job in jobs_list:
         name = raw_job["name"]

--- a/tools/tests/test_generate_test_status.py
+++ b/tools/tests/test_generate_test_status.py
@@ -5,6 +5,9 @@ import importlib
 import os
 import sys
 
+import pytest
+import requests
+
 sys.path.insert(
     0, "/".join(os.path.dirname(os.path.realpath(__file__)).split("/")[:-1])
 )
@@ -55,11 +58,69 @@ def test_fetch_jobs_returns_empty_list_for_error_payload():
         def json(self):
             return {"message": "Bad credentials"}
 
-    def fake_get(url, headers):
+    def fake_get(url, headers, timeout):
         seen["url"] = url
         seen["headers"] = headers
+        seen["timeout"] = timeout
         return Response()
 
     assert module.fetch_jobs("TOKEN", "gap-system/PackageDistro", "123", fake_get) == []
-    assert "filter=all" in seen["url"]
+    assert "filter=latest" in seen["url"]
+    assert "per_page=50" in seen["url"]
     assert seen["headers"] == {"Authorization": "Bearer TOKEN"}
+    assert seen["timeout"] == module.GITHUB_API_TIMEOUT
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload, next_url=None):
+        self.status_code = status_code
+        self.payload = payload
+        self.links = {"next": {"url": next_url}} if next_url else {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+    def json(self):
+        return self.payload
+
+
+def test_fetch_jobs_retries_transient_errors_on_each_page(monkeypatch):
+    module = importlib.import_module("generate_test_status")
+    next_url = "https://api.github.test/jobs?page=2"
+    responses = iter(
+        [
+            FakeResponse(200, {"jobs": [{"name": "first"}]}, next_url),
+            FakeResponse(502, {"message": "Server Error"}),
+            FakeResponse(200, {"jobs": [{"name": "second"}]}),
+        ]
+    )
+    seen_urls = []
+    delays = []
+
+    def fake_get(url, headers, timeout):
+        seen_urls.append(url)
+        return next(responses)
+
+    monkeypatch.setattr(module.time, "sleep", delays.append)
+
+    jobs = module.fetch_jobs("TOKEN", "gap-system/PackageDistro", "123", fake_get)
+
+    assert [job["name"] for job in jobs] == ["first", "second"]
+    assert seen_urls[-2:] == [next_url, next_url]
+    assert delays == [2]
+
+
+def test_fetch_jobs_does_not_retry_permanent_errors(monkeypatch):
+    module = importlib.import_module("generate_test_status")
+    calls = []
+
+    def fake_get(url, headers, timeout):
+        calls.append(url)
+        return FakeResponse(404, {"message": "Not Found"})
+
+    monkeypatch.setattr(module.time, "sleep", lambda delay: None)
+
+    with pytest.raises(requests.HTTPError):
+        module.fetch_jobs("TOKEN", "gap-system/PackageDistro", "123", fake_get)
+    assert len(calls) == 1


### PR DESCRIPTION
Query only the latest workflow attempt and retry transient GitHub API
failures while collecting paginated job results.

AI assistance: Codex implemented and verified this change.

Co-authored-by: Codex <codex@openai.com>
